### PR TITLE
Add tendencies output

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -172,7 +172,25 @@ state    real   umaxw          ij       dyn_em      1        X     i1  "UMAXW"  
 state    real   utrop          ij       dyn_em      1        X     i1  "UTROP"      "U-component of the tropopause wind" "m s-1"
 state    real   vmaxw          ij       dyn_em      1        Y     i1  "VMAXW"      "V-component of the max wind speed"  "m s-1"
 state    real   vtrop          ij       dyn_em      1        Y     i1  "VTROP"      "V-component of the tropopause wind" "m s-1"
-state    real   erod           ij.      misc        1        -     i012rd  "EROD" "fraction of erodible surface in each grid cell (0-1)"       "none"
+
+# --------------------------------------------------------------------------------------
+# new tendency variables for dynamical analysis - (NM 2013)
+# --------------------------------------------------------------------------------------
+
+state   real    ru_tend_adv     ikj     dyn_em          1               X               irh "RU_TEND_ADV"       "u-advection tendency" ""
+state   real    ru_tend_pgf     ikj     dyn_em          1               X               irh "RU_TEND_PGF"       "u-pressure gradient tendency" ""
+state   real    ru_tend_cor     ikj     dyn_em          1               X               irh "RU_TEND_COR"       "u-coriolis tendency" ""
+state   real    ru_tend_curv    ikj     dyn_em          1               X               irh "RU_TEND_CURV"      "u curvature gradient tendency" ""
+state   real    ru_tend_hdiff   ikj     dyn_em          1               X               irh "RU_TEND_HDIFF" "u horizontal diffusion tendency" ""
+state   real    ru_tend_phys    ikj     dyn_em          1               X               irh "RU_TEND_PHYS"      "total u physics tendency" ""
+
+state   real    rv_tend_adv     ikj     dyn_em          1               Y               irh "RV_TEND_ADV"       "v-advection tendency" ""
+state   real    rv_tend_pgf     ikj     dyn_em          1               Y               irh "RV_TEND_PGF"       "v-pressure gradient tendency" ""
+state   real    rv_tend_cor     ikj     dyn_em          1               Y               irh "RV_TEND_COR"       "v-coriolis tendency" ""
+state   real    rv_tend_curv    ikj     dyn_em          1               Y               irh "RV_TEND_CURV"      "v curvature gradient tendency" ""
+state   real    rv_tend_hdiff   ikj     dyn_em          1               Y               irh "RV_TEND_HDIFF" "v horizontal diffusion tendency" ""
+state   real    rv_tend_phys    ikj     dyn_em          1               Y               irh "RV_TEND_PHYS"      "total v physics tendency" ""
+state   real    t_tend_adv     ikj     dyn_em          1               -               irh "T_TEND_ADV"       "t-advection tendency" ""
 
 #-----------------------------------------------------------------------------------------------------------------------------------------------------------------
 #                                               
@@ -186,7 +204,7 @@ state    real   u              ikjb     dyn_em      2         X     \
      i0rhusdf=(bdy_interp:dt)       "U"                      "x-wind component"   "m s-1"
 state    real   ru             ikj     dyn_em      1         X      -        "MU_U"        "mu-coupled u"   "Pa m s-1"
 state    real   ru_m           ikj     dyn_em      1         X      -        "ru_m"        ""   ""
-state    real   ru_tend        ikj     dyn_em      1         X      -        "ru_tend"        ""   ""                                   
+state    real   ru_tend        ikj     dyn_em      1         X      h        "ru_tend"        ""   ""                                   
 i1       real   ru_tendf       ikj     dyn_em      1         X                                          
 state    real   u_save         ikj     dyn_em      1         X      -        "u_save"
 state    real   z_force        |       dyn_em      1         -      i3rh     "Z_FORCE" "height of forcing input" "m"
@@ -199,7 +217,7 @@ state    real   v              ikjb     dyn_em      2         Y     \
      i0rhusdf=(bdy_interp:dt)        "V"                     "y-wind component"   "m s-1"
 state    real   rv             ikj     dyn_em      1         Y      -        "MU_V"        "mu-coupled v"   "Pa m s-1"
 state    real   rv_m           ikj     dyn_em      1         Y      -        "rv_m"
-state    real   rv_tend        ikj     dyn_em      1         Y      -        "rv_tend"
+state    real   rv_tend        ikj     dyn_em      1         Y      h        "rv_tend"
 i1       real   rv_tendf       ikj     dyn_em      1         Y                                          
 state    real   v_save         ikj     dyn_em      1         Y      -        "v_save"                   
 state    real   v_g            |       dyn_em      1         -      i3rh     "V_G" "y-direction geostrophic wind" "m s-1"
@@ -316,11 +334,11 @@ state    real   mub_fine        ij     dyn_em      1         -      -           
 state    real   mub_save        ij     dyn_em      1         -      -           "mub_save" "nest temp, holds orig fine grid mub" "Pa"
 state    real   mu0             ij     dyn_em      1         -      i1          "mu0" "initial dry mass in column" "Pa"
 state    real   mudf            ij     dyn_em      1         -      -           "mudf" "" ""
-state    real   muu             ij     dyn_em      1          X     -           "muu"
+state    real   muu             ij     dyn_em      1          X     h           "muu"
 state    real   muus            ij     dyn_em      1          X     -           "muus"
-state    real   muv             ij     dyn_em      1          Y     -           "muv"
+state    real   muv             ij     dyn_em      1          Y     h           "muv"
 state    real   muvs            ij     dyn_em      1          Y     -           "muvs"
-state    real   mut             ij     dyn_em      1          -     -           "mut"
+state    real   mut             ij     dyn_em      1          -     h           "mut"
 state    real   muts            ij     dyn_em      1          -     -           "muts"
 i1       real   muave           ij     dyn_em      1          -     
 i1       real   mu_save         ij     dyn_em      1          -     

--- a/dyn_em/module_em.F
+++ b/dyn_em/module_em.F
@@ -188,6 +188,9 @@ END SUBROUTINE rk_step_prep
 
 SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                          ru_tend, rv_tend, rw_tend, ph_tend, t_tend,      &
+                         ru_tend_cor, ru_tend_adv, ru_tend_pgf, ru_tend_curv, ru_tend_hdiff,        & !added line for u (NM) 
+                         rv_tend_cor, rv_tend_adv, rv_tend_pgf, rv_tend_curv, rv_tend_hdiff,        & !added line for v (NM)
+                         t_tend_adv,                                      &     !added line for t (JSR)  
                          ru_tendf, rv_tendf, rw_tendf, ph_tendf, t_tendf, &
                          mu_tend, u_save, v_save, w_save, ph_save,        &
                          t_save, mu_save, RTHFTEN,                        &
@@ -261,6 +264,17 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                                                          rv_tend, &
                                                          rw_tend, &
                                                          t_tend,  &
+                                                         ru_tend_cor, & !added u
+                                                         ru_tend_adv, & !added u
+                                                         ru_tend_pgf, & !added u
+                                                         ru_tend_curv, & !added u
+                                                         ru_tend_hdiff, & !added u
+                                                         rv_tend_cor, & !added v
+                                                         rv_tend_adv, & !added v
+                                                         rv_tend_pgf, & !added v
+                                                         rv_tend_curv, & !added v
+                                                         rv_tend_hdiff, & !added v
+                                                         t_tend_adv,  & !added t				
                                                          ph_tend, &
                                                          RTHFTEN, &
                                                           u_save, &
@@ -333,6 +347,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
    REAL    :: kdift, khdq, kvdq, cfn, cfn1, cf1, cf2, cf3
    INTEGER :: i,j,k
    INTEGER :: time_step
+   REAL , DIMENSION( ims:ime , kms:kme, jms:jme  ) :: ru_tend_old, rv_tend_old, t_tend_old
 
 !<DESCRIPTION>
 !
@@ -431,7 +446,8 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                    its, ite, jts, jte, kts, kte )
 
      ELSE
-     
+
+     ru_tend_old = ru_tend                           !!NM: added line record current ru_tendency     
      CALL advect_u ( u, u , ru_tend, ru, rv, ww, &
                    c1h, c2h,                     &
                    mut, time_step, config_flags, &
@@ -441,6 +457,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                    ids, ide, jds, jde, kds, kde, &
                    ims, ime, jms, jme, kms, kme, &
                    its, ite, jts, jte, kts, kte )
+        ru_tend_adv = ru_tend - ru_tend_old             !!NM: added line for u_adv		   
       ENDIF
 
      IF( (rk_step == 3) .and. ( adv_opt == WENO_MOM ) ) THEN
@@ -456,7 +473,8 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                    its, ite, jts, jte, kts, kte )
 
     ELSE
-     
+
+     rv_tend_old = rv_tend                              !!NM: added line record current rv_tendency     
      CALL advect_v ( v, v , rv_tend, ru, rv, ww,  &
                    c1h, c2h,                     &
                    mut, time_step, config_flags, &
@@ -466,6 +484,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                    ids, ide, jds, jde, kds, kde, &
                    ims, ime, jms, jme, kms, kme, &
                    its, ite, jts, jte, kts, kte )
+     rv_tend_adv = rv_tend - rv_tend_old             !!NM: added line for v_adv		   
     ENDIF
 
 
@@ -524,7 +543,8 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                           rdx, rdy, rdnw,               &
                           ids, ide, jds, jde, kds, kde, &
                           ims, ime, jms, jme, kms, kme, &
-                          its, ite, jts, jte, kts, kte )
+                          its, ite, jts, jte, kts, kte ) 
+     t_tend_adv = t_tend - t_tend_old               !!JSR: added line for t_tend_adv
 
      ENDIF
      
@@ -556,6 +576,9 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                   ims, ime, jms, jme, kms, kme,      &
                   its, ite, jts, jte, kts, kte      )
 
+     ru_tend_old = ru_tend                              !!NM: added line record current ru_tenden
+     rv_tend_old = rv_tend                              !!NM: added line record current rv_tenden
+
      CALL horizontal_pressure_gradient( ru_tend,rv_tend,                 &
                                          ph,alt,p,pb,al,php,cqu,cqv,     &
                                          muu,muv,mu,c1h,c2h,fnm,fnp,rdnw,&
@@ -568,6 +591,9 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                                          ims, ime, jms, jme, kms, kme,   &
                                          its, ite, jts, jte, kts, kte   )
 
+     ru_tend_pgf = ru_tend - ru_tend_old               !added line ru pgf tendency
+     rv_tend_pgf = rv_tend - rv_tend_old               !added line rv pgf tendency
+					 
      IF (non_hydrostatic) THEN
           CALL pg_buoy_w( rw_tend, p, cqw, mu, mub,       &
                           c1f,c2f,                        &
@@ -600,6 +626,9 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                                        ims, ime, jms, jme, kms, kme, &
                                        its, ite, jts, jte, kts, kte )
      ELSE
+     
+     ru_tend_old = ru_tend                              !!NM: added line record current ru_tenden
+     rv_tend_old = rv_tend                              !!NM: added line record current rv_tenden     
           CALL coriolis ( ru, rv, rw,                   &
                           ru_tend,  rv_tend,  rw_tend,  &
                           config_flags,                 &
@@ -609,9 +638,13 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                           ids, ide, jds, jde, kds, kde, &
                           ims, ime, jms, jme, kms, kme, &
                           its, ite, jts, jte, kts, kte )
-
+     ru_tend_cor = ru_tend - ru_tend_old               !added line ru for coriolis tendency
+     rv_tend_cor = rv_tend - rv_tend_old               !added line rv for coriolis tendency
+			  
      END IF
 
+     ru_tend_old = ru_tend                              !!NM: added line record current ru_tenden
+     rv_tend_old = rv_tend                              !!NM: added line record current rv_tenden
      CALL curvature ( ru, rv, rw, u, v, w,            &
                        ru_tend,  rv_tend,  rw_tend,    &
                        config_flags,                   &
@@ -621,6 +654,9 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                        ids, ide, jds, jde, kds, kde,   &
                        ims, ime, jms, jme, kms, kme,   &
                        its, ite, jts, jte, kts, kte   )
+     ru_tend_curv = ru_tend - ru_tend_old               !added line ru for curvature tendency
+     rv_tend_curv = rv_tend - rv_tend_old               !added line rv for curvature tendency
+		       
 
 ! Damping option added for Held-Suarez test (also uses lw option HELDSUAREZ)
       IF (config_flags%ra_lw_physics == HELDSUAREZ) THEN
@@ -642,6 +678,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
 
     diff_opt1 : IF (config_flags%diff_opt .eq. 1) THEN
    
+        ru_tend_old = ru_tendf                          !!NM: added line record current ru_tenden
         CALL horizontal_diffusion ('u', u, ru_tendf, mut,               &
                                         c1h, c2h, config_flags,         &
                                         msfux, msfuy, msfvx, msfvx_inv, &
@@ -650,7 +687,9 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                                         ids, ide, jds, jde, kds, kde,   &
                                         ims, ime, jms, jme, kms, kme,   &
                                         its, ite, jts, jte, kts, kte   )
+        ru_tend_hdiff = ru_tendf - ru_tend_old               !added line ru for diffusion tendency
 
+        rv_tend_old = rv_tendf                          !!NM: added line record current rv_tenden
         CALL horizontal_diffusion ('v', v, rv_tendf, mut,               &
                                         c1h, c2h, config_flags,         &
                                         msfux, msfuy, msfvx, msfvx_inv, &
@@ -659,6 +698,7 @@ SUBROUTINE rk_tendency ( config_flags, rk_step,                           &
                                         ids, ide, jds, jde, kds, kde,   &
                                         ims, ime, jms, jme, kms, kme,   &
                                         its, ite, jts, jte, kts, kte   )
+        rv_tend_hdiff = rv_tendf - rv_tend_old               !added line rv for hdiff tendency
 
         CALL horizontal_diffusion ('w', w, rw_tendf, mut,               &
                                         c1f, c2f, config_flags,         &
@@ -799,6 +839,7 @@ END SUBROUTINE rk_tendency
 
 SUBROUTINE rk_addtend_dry ( ru_tend, rv_tend, rw_tend, ph_tend, t_tend,      &
                             ru_tendf, rv_tendf, rw_tendf, ph_tendf, t_tendf, &
+                            ru_tend_phys, rv_tend_phys,                      & !added line (NM)
                             u_save, v_save, w_save, ph_save, t_save,         &
                             mu_tend, mu_tendf, rk_step, c1, c2,              &
                             h_diabatic, mut, msftx, msfty, msfux, msfuy,     &
@@ -828,6 +869,10 @@ SUBROUTINE rk_addtend_dry ( ru_tend, rv_tend, rw_tend, ph_tend, t_tend,      &
                                                                       rw_tendf, &
                                                                       ph_tendf, &
                                                                       t_tendf
+
+  REAL , DIMENSION( ims:ime , kms:kme, jms:jme  ) , INTENT(OUT) :: ru_tend_phys, &
+
+  rv_tend_phys
 
    REAL , DIMENSION( ims:ime , jms:jme  ) , INTENT(INOUT) :: mu_tend, &
                                                              mu_tendf
@@ -885,6 +930,9 @@ SUBROUTINE rk_addtend_dry ( ru_tend, rv_tend, rw_tend, ph_tend, t_tend,      &
    ENDDO
    ENDDO
    ENDDO
+
+   ru_tend_phys = ru_tendf              !added line for exporting dynamics (NM)
+   rv_tend_phys = rv_tendf              !added line for exporting dynamics (NM)
 
    DO j = jts,jte
    DO k = kts,kte-1

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -800,6 +800,9 @@ BENCH_START(rk_tend_tim)
        CALL wrf_debug ( 200 , ' call rk_tendency' )
        CALL rk_tendency ( config_flags, rk_step                                                                &
                          ,grid%ru_tend, grid%rv_tend, rw_tend, ph_tend, t_tend                                 &
+			 ,grid%ru_tend_cor, grid%ru_tend_adv, grid%ru_tend_pgf, grid%ru_tend_curv, grid%ru_tend_hdiff      & !added line for u tendencies (NM)
+                         ,grid%rv_tend_cor, grid%rv_tend_adv, grid%rv_tend_pgf, grid%rv_tend_curv, grid%rv_tend_hdiff      & !added line for v tendencies (NM)
+			 ,grid%t_tend_adv									       &	!added line for t_adv (JSR)
                          ,ru_tendf, rv_tendf, rw_tendf, ph_tendf, t_tendf                                      &
                          ,mu_tend, grid%u_save, grid%v_save, w_save, ph_save                                   &
                          ,grid%t_save, mu_save, grid%rthften                                                   &
@@ -886,6 +889,7 @@ BENCH_START(relax_bdy_dry_tim)
 
        CALL rk_addtend_dry( grid%ru_tend,  grid%rv_tend,  rw_tend,  ph_tend,  t_tend,  &
                             ru_tendf, rv_tendf, rw_tendf, ph_tendf, t_tendf, &
+                                                        grid%ru_tend_phys, grid%rv_tend_phys, &                 ! added line for extracting physics tendencies (NM)
                             grid%u_save, grid%v_save, w_save, ph_save, grid%t_save, &
                             mu_tend, mu_tendf, rk_step,                      &
                             grid%c1h, grid%c2h,                              &
@@ -3553,7 +3557,7 @@ BENCH_START(moist_physics_prep_tim)
          CALL wrf_debug ( 200 , ' call bulk_dust_emis' )
          CALL bulk_dust_emis (grid%itimestep,dtm,config_flags%num_soil_layers  &
                ,grid%u_phy,grid%v_phy,grid%rho,grid%alt                        &
-               ,grid%u10,grid%v10,p8w,dz8w,grid%smois,grid%erod                &
+               ,grid%u10,grid%v10,p8w,dz8w,grid%smois,grid%aerod                &
                ,grid%ivgtyp,grid%isltyp,grid%vegfra,grid%albbck,grid%xland     &
                ,grid%dx, g, grid%qnifa2d, ids,ide, jds,jde, kds,kde            &
                ,ims,ime, jms,jme, kms,kme                                      &


### PR DESCRIPTION
@cdraxl's changes for tendency output (from WRF v3.7.1), as implemented by @phawbeck. 

Note that the changes were implemented on top of NCAR release v4.1.2, which is the point at which a2e-mmc:master will be frozen until we have an MMC release. 