### PR TITLE
Fixed removal of initial perturbations and proper adjustment of skin …

### DIFF
--- a/Registry/registry.les
+++ b/Registry/registry.les
@@ -19,8 +19,10 @@ state   real    r13     ikjf    nba_rij		1       -       -       "r13"   	"13 co
 state   real    r23     ikjf    nba_rij		1       -       -       "r23"   	"23 component of rotation tensor"               "s-1"
 state   real    smnsmn  ikjf    nba_rij		1       -       -       "smnsmn"   	"Smn*Smn"               			"s-2"
 
-rconfig	real 	spec_hfx 	namelist,dynamics	1     		-999.9  -	"Constant surface heat flux (W/m^2) for use with sf_sfclay_physics=1. -999.9 ignores this option."
-rconfig	real 	spec_lat 	namelist,dynamics	1     		-999.9  -	"Latitude to compute coriolis terms for idealized simulations. -999.9 ignores this option."
+rconfig logical spec_ideal          namelist,dynamics   1           .false.  -  "flag to activate spec_hfx and spec_z0 in sf_sfclay_physics=1 and spec_lat in the initialization" # DME-MMC
+rconfig real    spec_hfx            namelist,dynamics   1               0.0  -  "Constant surface heat flux (W/m^2) for use with sf_sfclay_physics=1 in ideal conditions (spec_ideal=.true.)" # DME-MMC
+rconfig real    spec_z0         namelist,dynamics       1               0.1  -  "Homogeneous roughness length (m) for use with sf_sfclay_physics=1 in ideal conditions (spec_ideal=.true.)" # DME-MMC
+rconfig real    spec_lat        namelist,dynamics       1              33.6  -  "Latitude to compute coriolis terms for idealized simulations (spec_ideal=.true.)"
 
 rconfig	integer sfs_opt 	namelist,dynamics	max_domains     0       -	"1 or 2 to use NBA models"
 rconfig	integer m_opt    	namelist,dynamics       max_domains     0       -       "1 to output sgs stresses if not using NBA"

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -497,6 +497,8 @@ BENCH_START(surf_driver_tim)
      &        ,P8W=grid%p_hyd_w            ,PBLH=grid%pblh          ,PI_PHY=pi_phy      &
      &        ,PSFC=grid%psfc          ,PSHLTR=grid%pshltr      ,PSIH=psih          &
      &        ,SPEC_HFX=config_flags%spec_hfx                                       & !JDM-MMC
+     &        ,SPEC_Z0=config_flags%spec_z0                                         & ! DME-MMC
+     &        ,SPEC_IDEAL=config_flags%spec_ideal                                   & ! DME-MMC
      &        ,BLDT=grid%bldt     ,CURR_SECS=curr_secs, ADAPT_STEP_FLAG=adapt_step_flag  &
      &        ,BLDTACTTIME=grid%bldtacttime                                              & 
      &        ,PSIM=psim          ,P_PHY=grid%p_hyd        ,Q10=grid%q10            &

--- a/dyn_em/module_initialize_ideal.F
+++ b/dyn_em/module_initialize_ideal.F
@@ -600,7 +600,9 @@ CONTAINS
    END DO
 
 !JDM-MMC Compute Coriolis terms from specified latitude.
-IF ( config_flags%spec_lat .NE. -999.9 ) THEN
+!IF ( config_flags%spec_lat .NE. -999.9 ) THEN
+! DME-MMC use the flag for ideal settings
+IF ( config_flags%spec_ideal ) THEN
    
     DO j = jts, jte
       DO i = its, ite
@@ -1374,14 +1376,15 @@ ENDIF
 ! For 2D test, call randx outside I-loop
 ! For 3D runs, call randx inside both I-J loops
 
-  DO J = jts, min(jde-1,jte)
+! DME-MMC removes initial perturbations and hydrostatic rebalancing
+!  DO J = jts, min(jde-1,jte)
 !   yrad = config_flags%dy*float(j-nyc)/10000.
-    yrad = 0.
-    DO I = its, min(ide-1,ite)
+!    yrad = 0.
+!    DO I = its, min(ide-1,ite)
 !     xrad = config_flags%dx*float(i-nxc)/10000.
-      xrad = 0.
-      call random_number (randx)
-      randx = randx - 0.5
+!      xrad = 0.
+!      call random_number (randx)
+!      randx = randx - 0.5
 !     DO K = 1, kte-1
 !JDM-MMC Comment removes initialization perturbations      DO K = 1, 4
 
@@ -1393,34 +1396,35 @@ ENDIF
 !       zrad = 0.5*(grid%ph_1(i,k,j)+grid%ph_1(i,k+1,j)  &
 !                  +grid%phb(i,k,j)+grid%phb(i,k+1,j))/g
 !       zrad = (zrad-1500.)/1500.
-        zrad = 0.
-        RAD=SQRT(xrad*xrad+yrad*yrad+zrad*zrad)
-        IF(RAD <= 1.) THEN
+!        zrad = 0.
+!        RAD=SQRT(xrad*xrad+yrad*yrad+zrad*zrad)
+!        IF(RAD <= 1.) THEN
 !          grid%t_1(i,k,j)=grid%t_1(i,k,j)+delt*COS(.5*PI*RAD)**2
-           grid%t_1(i,k,j)=grid%t_1(i,k,j)+ 0.1 *randx
-           grid%t_2(i,k,j)=grid%t_1(i,k,j)
-           qvf = 1. + rvovrd*moist(i,k,j,P_QV)
-           grid%alt(i,k,j) = (r_d/p1000mb)*(grid%t_1(i,k,j)+t0)*qvf* &
-                        (((grid%p(i,k,j)+grid%pb(i,k,j))/p1000mb)**cvpm)
-           grid%al(i,k,j) = grid%alt(i,k,j) - grid%alb(i,k,j)
-        ENDIF
+!           grid%t_1(i,k,j)=grid%t_1(i,k,j)+ 0.1 *randx
+!           grid%t_2(i,k,j)=grid%t_1(i,k,j)
+!           qvf = 1. + rvovrd*moist(i,k,j,P_QV)
+!           grid%alt(i,k,j) = (r_d/p1000mb)*(grid%t_1(i,k,j)+t0)*qvf* &
+!                        (((grid%p(i,k,j)+grid%pb(i,k,j))/p1000mb)**cvpm)
+!           grid%al(i,k,j) = grid%alt(i,k,j) - grid%alb(i,k,j)
+!        ENDIF
 !JDM-MMC      ENDDO
 
 !  rebalance hydrostatically
 
 
-      DO  kk  = 2,kte
-        k = kk - 1
-        grid%ph_1(i,kk,j) = grid%ph_1(i,kk-1,j) - (grid%dnw(kk-1))*(       &
-                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,kk-1,j)+ &
-                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,kk-1,j)  )
-
-        grid%ph_2(i,kk,j) = grid%ph_1(i,kk,j)
-        grid%ph0(i,kk,j) = grid%ph_1(i,kk,j) + grid%phb(i,kk,j)
-      ENDDO
-
-    ENDDO
-  ENDDO
+!      DO  kk  = 2,kte
+!        k = kk - 1
+!        grid%ph_1(i,kk,j) = grid%ph_1(i,kk-1,j) - (grid%dnw(kk-1))*(       &
+!                     ((grid%c1h(k)*grid%mub(i,j)+grid%c2h(k))+(grid%c1h(k)*grid%mu_1(i,j)))*grid%al(i,kk-1,j)+ &
+!                      (grid%c1h(k)*grid%mu_1(i,j))*grid%alb(i,kk-1,j)  )
+!
+!        grid%ph_2(i,kk,j) = grid%ph_1(i,kk,j)
+!        grid%ph0(i,kk,j) = grid%ph_1(i,kk,j) + grid%phb(i,kk,j)
+!      ENDDO
+!
+!    ENDDO
+!  ENDDO
+! DME-MMC
 
   END SELECT ideal_pert
 

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -25,6 +25,9 @@ CONTAINS
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      spec_hfx,                                     & !JDM-MMC
+                     curr_secs,                                    & ! DME-MMC
+                     spec_z0,                                      & ! DME-MMC
+                     spec_ideal,                                   & ! DME-MMC
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux )
      
 !-------------------------------------------------------------------
@@ -188,6 +191,12 @@ CONTAINS
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
 
       REAL,     INTENT(IN   )            ::   spec_hfx        !JDM-MMC
+
+      REAL,     OPTIONAL, INTENT(IN   )  ::   curr_secs       ! DME-MMC
+
+      REAL,     INTENT(IN   )            ::   spec_z0         ! DME-MMC
+
+      LOGICAL,  INTENT(IN   )            ::   spec_ideal      ! DME-MMC
       
       REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme )              , &
                 INTENT(OUT)     ::                  ck,cka,cd,cda
@@ -209,6 +218,32 @@ CONTAINS
       REAL,     DIMENSION( its:ite ) ::                    dz8w1d
 
       INTEGER ::  I,J
+
+      REAL :: dth_i, thx_i ! DME-MMC
+
+! DME-MMC modifications to set z0 and properly calculate TSK from an imposed heat flux (spec_hfx, W m-2)
+      IF ( spec_ideal ) THEN
+        IF (curr_secs .eq. 0.) THEN ! set z0
+          DO J=jts,jte
+            DO I=its,ite
+              znt(i,j) = spec_z0
+            ENDDO
+          ENDDO
+        ELSE ! set tsk according to namelist specified feat flux
+          DO J=jts,jte
+            DO I=its,ite
+              IF (spec_hfx .eq. 0. .OR. flhc(i,j) .eq. 0. ) THEN
+                dth_i = 0.
+              ELSE
+                dth_i = spec_hfx/flhc(i,j)
+              ENDIF
+              thx_i = t3d(i,1,j)*(P1000mb/p3d(i,1,j))**rovcp
+              tsk(i,j) = (dth_i + thx_i)/(P1000mb/(psfc(i,j)))**rovcp
+            ENDDO
+          ENDDO
+        ENDIF
+      ENDIF
+! DME-MMC
 
       DO J=jts,jte
         DO i=its,ite
@@ -245,9 +280,9 @@ CONTAINS
 #if ( EM_CORE == 1 )
                 ,isftcflx,iz0tlnd,scm_force_flux,                               &
                 USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
-                CD(ims,j),CDA(ims,j)                              &
+                CD(ims,j),CDA(ims,j)                               &
 #endif
-                ,spec_hfx                                           ) !JDM-MMC
+                                                                    )
       ENDDO
 
 
@@ -268,9 +303,7 @@ CONTAINS
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      isftcflx, iz0tlnd,scm_force_flux,                            &
-                     ustm,ck,cka,cd,cda,                           &
-                     spec_hfx                                      & !JDM-MMC
-                                                                   )
+                     ustm,ck,cka,cd,cda                            )
 !-------------------------------------------------------------------
       IMPLICIT NONE
 !-------------------------------------------------------------------
@@ -291,11 +324,8 @@ CONTAINS
       REAL,     DIMENSION( ims:ime )                             , &
                 INTENT(IN   )               ::             MAVAIL, &
                                                              PBLH, &
-                                                            XLAND
-      
-      REAL,     DIMENSION( ims:ime )                             , &  !JDM-MMC
-                INTENT(INOUT )               ::               TSK
-      
+                                                            XLAND, &
+                                                              TSK
 !
       REAL,     DIMENSION( ims:ime )                             , &
                 INTENT(IN   )               ::             PSFCPA
@@ -351,9 +381,6 @@ CONTAINS
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX, IZ0TLND
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
 
-      REAL,     INTENT(IN   )            ::   spec_hfx        !JDM-MMC
-
-      
 ! LOCAL VARS
 
       REAL,     DIMENSION( its:ite )        ::                 ZA, &
@@ -1065,26 +1092,6 @@ CONTAINS
         ENDIF
         
   400 CONTINUE                                                                 
-
-      IF( spec_hfx .NE. -999.9) THEN !JDM-MMC
-
-         !Specify heat flux from namelist, adjust TSK to be consistent with spec_hfx,
-         !and set the surface temperature to be consistent with spec_hfx
-
-         DO 403 I=its,ite   
-
-            HFX(I) = spec_hfx  
-            QFX(I) = 0.0
-            LH(I) = 0.0
-            FLQC(I) = 0.0
-              
-            THGB(I) = THX(I)
-
-            TSK(I) = THGB(I)/((100./PSFC(I))**ROVCP)
-
-  403    CONTINUE  
-  
-      ENDIF
 
   405 CONTINUE                                                                 
          

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -18,6 +18,8 @@ CONTAINS
      &          ,isltyp,itimestep,julian_in,ivgtyp,lowlyr,mavail,rmol &
      &          ,num_soil_layers,p8w,pblh,pi_phy,pshltr,fm,fhh,psih   &
      &          ,spec_hfx                                             & !JDM-MMC
+     &          ,spec_z0                                              & ! DME-MMC
+     &          ,spec_ideal                                           & ! DME-MMC
 #if (NMM_CORE==1)
      &          ,psim,p_phy,q10,q2,qfx,taux,tauy,qsfc,qshltr,qz0      &
      &          ,zkmax,ribn,charn,msang,scurx,scury,icoef_sf,iwavecpl,lcurr_sf & !for gfdl-sf drag
@@ -1165,7 +1167,9 @@ CONTAINS
    REAL,OPTIONAL, INTENT(IN   ) :: hfx_force_tend,lh_force_tend,tsk_force_tend
 
 
-   REAL, INTENT(IN ) :: spec_hfx !Constant surface heat flux (W/m^2) for use with sf_sfclay_physics=1 
+   LOGICAL, INTENT(IN ) :: spec_ideal ! Flag to activate idealized spec_hfx and spec_z0 ! DME-MMC
+   REAL,    INTENT(IN ) :: spec_hfx   ! Constant surface heat flux (W/m^2) for use with sf_sfclay_physics=1 and spec_ideal_sfclay=.true. !JDM-MMC
+   REAL,    INTENT(IN ) :: spec_z0    ! Constant roughness length (m) for use with sf_sfclay_physics=1 and spec_ideal_sfclay=.true. ! DME-MMC
    
 !  LOCAL  VAR
 
@@ -1979,6 +1983,9 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                          &
                  i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
                  spec_hfx,                                           &   !JDM-MMC            
+                 curr_secs,                                          & ! DME-MMC
+                 spec_z0,                                            & ! DME-MMC
+                 spec_ideal,                                         & ! DME-MMC
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
                  sf_surface_physics                                 )
                                                                      
@@ -1995,6 +2002,9 @@ CONTAINS
                ims,ime, jms,jme, kms,kme,                          &
                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte, &
                spec_hfx,                                              &   !JDM-MMC            
+               curr_secs,                                          & ! DME-MMC
+               spec_z0,                                            & ! DME-MMC
+               spec_ideal,                                         & ! DME-MMC
                ustm,ck,cka,cd,cda,isftcflx,iz0tlnd, scm_force_flux    )
                                                                       
 #if ( EM_CORE==1)
@@ -5565,6 +5575,9 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      spec_hfx,                                     &    !JDM-MMC
+                     curr_secs,                                    & ! DME-MMC
+                     spec_z0,                                      & ! DME-MMC
+                     spec_ideal,                                   & ! DME-MMC
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
                      sf_surface_physics                            )
      
@@ -5672,6 +5685,10 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                                                 ZNT_SEA
 
      REAL,     INTENT(IN)               ::      spec_hfx          !JDM-MMC
+     REAL,     OPTIONAL, INTENT(IN)     ::      curr_secs         ! DME-MMC   
+     REAL,     INTENT(IN)               ::      spec_z0           ! DME-MMC
+     LOGICAL,  INTENT(IN)               ::      spec_ideal        ! DME-MMC
+
      
 !--------------------------------------------------------------------
 !    Local
@@ -5819,6 +5836,9 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    &
                  spec_hfx,                                     &   !JDM-MMC
+                 curr_secs,                                    & ! DME-MMC
+                 spec_z0,                                      & ! DME-MMC
+                 spec_ideal,                                   & ! DME-MMC
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd          )
      
 !
@@ -5911,6 +5931,9 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    & ! 0
                  spec_hfx,                                     &            !JDM-MMC
+                 curr_secs,                                    & ! DME-MMC
+                 spec_z0,                                      & ! DME-MMC
+                 spec_ideal,                                   & ! DME-MMC
                  ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd )
     
 !


### PR DESCRIPTION
…temperature based on imposed surface heat flux.

These code modifications provide:
1) A fix to the removal of the initial perturbations for the idealized LES case.
2) Properly updated skin temperature in the surface layer routine (sf_sfclay_physics = 1). Also, new capability to set roughness length to a different value from the defaults has been added. These forcing settings for the idealized LES case are activated using the following added parameters:
spec_ideal                = .true., ! activates the the following parameters
spec_hfx                  = 200.0,
 spec_z0                   = 0.05,
 spec_lat                  = 33.6,

Several test have been performed to verify these modifications work as expected. The result is that now a mesoscale run will remain perfectly horizontally homogeneous and the skin temperature is adjusted properly to match spec_hfx, therefore passing surface exchange coefficients that are stability-aware into the PBL scheme or LES. With these modifications, a clean inflow is generated in a mesoscale domain, which can then be used to test inflow turbulence generation methods in nested LES.

The following figures demonstrate perfect horizontal homogeneity after 6h of surface heating being applied (200 W m-2), as well as a correct time-evolution of skin temperature.

<img width="885" alt="Screen Shot 2019-08-25 at 5 34 25 PM" src="https://user-images.githubusercontent.com/19294286/63657418-ebe4bb80-c75e-11e9-957e-126dc73bd89c.png">
<img width="664" alt="Screen Shot 2019-08-25 at 5 36 07 PM" src="https://user-images.githubusercontent.com/19294286/63657419-f1da9c80-c75e-11e9-9c69-4e7f8b651d31.png">


