### PR TITLE
fix to z0 initialization for nested domains in idealized runs

### DIFF
--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -25,9 +25,9 @@ CONTAINS
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      spec_hfx,                                     & !JDM-MMC
-                     curr_secs,                                    & ! DME-MMC
                      spec_z0,                                      & ! DME-MMC
                      spec_ideal,                                   & ! DME-MMC
+                     itimestep,                                    & ! DME-MMC
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux )
      
 !-------------------------------------------------------------------
@@ -192,11 +192,11 @@ CONTAINS
 
       REAL,     INTENT(IN   )            ::   spec_hfx        !JDM-MMC
 
-      REAL,     OPTIONAL, INTENT(IN   )  ::   curr_secs       ! DME-MMC
-
       REAL,     INTENT(IN   )            ::   spec_z0         ! DME-MMC
 
       LOGICAL,  INTENT(IN   )            ::   spec_ideal      ! DME-MMC
+
+      INTEGER,  INTENT(IN   )            ::   itimestep       ! DME-MMC
       
       REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme )              , &
                 INTENT(OUT)     ::                  ck,cka,cd,cda
@@ -223,7 +223,7 @@ CONTAINS
 
 ! DME-MMC modifications to set z0 and properly calculate TSK from an imposed heat flux (spec_hfx, W m-2)
       IF ( spec_ideal ) THEN
-        IF (curr_secs .eq. 0.) THEN ! set z0
+        IF (itimestep .eq. 1) THEN ! set z0
           DO J=jts,jte
             DO I=its,ite
               znt(i,j) = spec_z0

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -1983,7 +1983,6 @@ CONTAINS
                  ims,ime, jms,jme, kms,kme,                          &
                  i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte,    &
                  spec_hfx,                                           &   !JDM-MMC            
-                 curr_secs,                                          & ! DME-MMC
                  spec_z0,                                            & ! DME-MMC
                  spec_ideal,                                         & ! DME-MMC
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
@@ -2002,9 +2001,9 @@ CONTAINS
                ims,ime, jms,jme, kms,kme,                          &
                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte, &
                spec_hfx,                                              &   !JDM-MMC            
-               curr_secs,                                          & ! DME-MMC
                spec_z0,                                            & ! DME-MMC
                spec_ideal,                                         & ! DME-MMC
+               itimestep,                                          & ! DME-MMC
                ustm,ck,cka,cd,cda,isftcflx,iz0tlnd, scm_force_flux    )
                                                                       
 #if ( EM_CORE==1)
@@ -5575,7 +5574,6 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      spec_hfx,                                     &    !JDM-MMC
-                     curr_secs,                                    & ! DME-MMC
                      spec_z0,                                      & ! DME-MMC
                      spec_ideal,                                   & ! DME-MMC
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
@@ -5685,7 +5683,6 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                                                 ZNT_SEA
 
      REAL,     INTENT(IN)               ::      spec_hfx          !JDM-MMC
-     REAL,     OPTIONAL, INTENT(IN)     ::      curr_secs         ! DME-MMC   
      REAL,     INTENT(IN)               ::      spec_z0           ! DME-MMC
      LOGICAL,  INTENT(IN)               ::      spec_ideal        ! DME-MMC
 
@@ -5836,9 +5833,9 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    &
                  spec_hfx,                                     &   !JDM-MMC
-                 curr_secs,                                    & ! DME-MMC
                  spec_z0,                                      & ! DME-MMC
                  spec_ideal,                                   & ! DME-MMC
+                 itimestep,                                    & ! DME-MMC
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd          )
      
 !
@@ -5931,9 +5928,9 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    & ! 0
                  spec_hfx,                                     &            !JDM-MMC
-                 curr_secs,                                    & ! DME-MMC
                  spec_z0,                                      & ! DME-MMC
                  spec_ideal,                                   & ! DME-MMC
+                 itimestep,                                    & ! DME-MMC
                  ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd )
     
 !


### PR DESCRIPTION
This PR provides a fix for the initial setting of roughness length (spec_z0) in the case of nested domains under idealized conditions (sf_sfclay_physics = 1, spec_ideal = .true.).

This fix has been tested on a two domain simulation with nested domain initialized at a different time from the parent.