### PR TITLE
fix to surface layer on d01 when initializing nested domain

### DIFF
--- a/Registry/registry.les
+++ b/Registry/registry.les
@@ -23,6 +23,8 @@ rconfig logical spec_ideal          namelist,dynamics   1           .false.  -  
 rconfig real    spec_hfx            namelist,dynamics   1               0.0  -  "Constant surface heat flux (W/m^2) for use with sf_sfclay_physics=1 in ideal conditions (spec_ideal=.true.)" # DME-MMC
 rconfig real    spec_z0         namelist,dynamics       1               0.1  -  "Homogeneous roughness length (m) for use with sf_sfclay_physics=1 in ideal conditions (spec_ideal=.true.)" # DME-MMC
 rconfig real    spec_lat        namelist,dynamics       1              33.6  -  "Latitude to compute coriolis terms for idealized simulations (spec_ideal=.true.)"
+state   real    ustt              ij      misc          1                -  r  "ustt"  "temporary array for friction velocity" ! DME-MMC
+state   real    molt              ij      misc          1                -  r  "molt"  "temporary array for Obukhov length" ! DME-MMC
 
 rconfig	integer sfs_opt 	namelist,dynamics	max_domains     0       -	"1 or 2 to use NBA models"
 rconfig	integer m_opt    	namelist,dynamics       max_domains     0       -       "1 to output sgs stresses if not using NBA"

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -499,6 +499,8 @@ BENCH_START(surf_driver_tim)
      &        ,SPEC_HFX=config_flags%spec_hfx                                       & !JDM-MMC
      &        ,SPEC_Z0=config_flags%spec_z0                                         & ! DME-MMC
      &        ,SPEC_IDEAL=config_flags%spec_ideal                                   & ! DME-MMC
+     &        ,USTT=grid%ustt                                                       & ! DME-MMC
+     &        ,MOLT=grid%molt                                                       & ! DME-MMC
      &        ,BLDT=grid%bldt     ,CURR_SECS=curr_secs, ADAPT_STEP_FLAG=adapt_step_flag  &
      &        ,BLDTACTTIME=grid%bldtacttime                                              & 
      &        ,PSIM=psim          ,P_PHY=grid%p_hyd        ,Q10=grid%q10            &

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -28,6 +28,8 @@ CONTAINS
                      spec_z0,                                      & ! DME-MMC
                      spec_ideal,                                   & ! DME-MMC
                      itimestep,                                    & ! DME-MMC
+                     ustt,                                         & ! DME-MMC
+                     molt,                                         & ! DME-MMC
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux )
      
 !-------------------------------------------------------------------
@@ -197,6 +199,8 @@ CONTAINS
       LOGICAL,  INTENT(IN   )            ::   spec_ideal      ! DME-MMC
 
       INTEGER,  INTENT(IN   )            ::   itimestep       ! DME-MMC
+
+      REAL,     DIMENSION( ims:ime, jms:jme ), INTENT(INOUT)   ::   ustt,molt ! DME-MMC
       
       REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme )              , &
                 INTENT(OUT)     ::                  ck,cka,cd,cda
@@ -223,22 +227,27 @@ CONTAINS
 
 ! DME-MMC modifications to set z0 and properly calculate TSK from an imposed heat flux (spec_hfx, W m-2)
       IF ( spec_ideal ) THEN
-        IF (itimestep .eq. 1) THEN ! set z0
-          DO J=jts,jte
-            DO I=its,ite
-              znt(i,j) = spec_z0
-            ENDDO
+        DO J=jts,jte
+          DO I=its,ite
+            ust(i,j) = ustt(i,j)
+            mol(i,j) = molt(i,j)
+            znt(i,j) = spec_z0
           ENDDO
-        ELSE ! set tsk according to namelist specified feat flux
+        ENDDO
+        IF (itimestep .ne. 1) THEN ! set z0
           DO J=jts,jte
             DO I=its,ite
-              IF (spec_hfx .eq. 0. .OR. flhc(i,j) .eq. 0. ) THEN
+              IF (spec_hfx .eq. 0.) THEN
                 dth_i = 0.
-              ELSE
+                thx_i = t3d(i,1,j)*(P1000mb/p3d(i,1,j))**rovcp
+                tsk(i,j) = (dth_i + thx_i)/(P1000mb/(psfc(i,j)))**rovcp
+              ELSEIF (flhc(i,j) .ne. 0. ) THEN
                 dth_i = spec_hfx/flhc(i,j)
+                thx_i = t3d(i,1,j)*(P1000mb/p3d(i,1,j))**rovcp
+                tsk(i,j) = (dth_i + thx_i)/(P1000mb/(psfc(i,j)))**rovcp
+              ELSE
+                ! do nothing, flhc(i,j) = 0.0...
               ENDIF
-              thx_i = t3d(i,1,j)*(P1000mb/p3d(i,1,j))**rovcp
-              tsk(i,j) = (dth_i + thx_i)/(P1000mb/(psfc(i,j)))**rovcp
             ENDDO
           ENDDO
         ENDIF
@@ -284,6 +293,15 @@ CONTAINS
 #endif
                                                                     )
       ENDDO
+
+      IF ( spec_ideal ) THEN
+        DO J=jts,jte ! DME-MMC
+          DO I=its,ite
+            ustt(i,j) = ust(i,j)
+            molt(i,j) = mol(i,j)
+          ENDDO
+        ENDDO
+      ENDIF
 
 
    END SUBROUTINE SFCLAYREV

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -20,6 +20,8 @@ CONTAINS
      &          ,spec_hfx                                             & !JDM-MMC
      &          ,spec_z0                                              & ! DME-MMC
      &          ,spec_ideal                                           & ! DME-MMC
+     &          ,ustt                                                 & ! DME-MMC
+     &          ,molt                                                 & ! DME-MMC
 #if (NMM_CORE==1)
      &          ,psim,p_phy,q10,q2,qfx,taux,tauy,qsfc,qshltr,qz0      &
      &          ,zkmax,ribn,charn,msang,scurx,scury,icoef_sf,iwavecpl,lcurr_sf & !for gfdl-sf drag
@@ -1170,6 +1172,7 @@ CONTAINS
    LOGICAL, INTENT(IN ) :: spec_ideal ! Flag to activate idealized spec_hfx and spec_z0 ! DME-MMC
    REAL,    INTENT(IN ) :: spec_hfx   ! Constant surface heat flux (W/m^2) for use with sf_sfclay_physics=1 and spec_ideal_sfclay=.true. !JDM-MMC
    REAL,    INTENT(IN ) :: spec_z0    ! Constant roughness length (m) for use with sf_sfclay_physics=1 and spec_ideal_sfclay=.true. ! DME-MMC
+   REAL,    DIMENSION( ims:ime, jms:jme ) , INTENT(INOUT)::   USTT, MOLT ! DME-MMC
    
 !  LOCAL  VAR
 
@@ -1985,6 +1988,8 @@ CONTAINS
                  spec_hfx,                                           &   !JDM-MMC            
                  spec_z0,                                            & ! DME-MMC
                  spec_ideal,                                         & ! DME-MMC
+                 ustt,                                               & ! DME-MMC
+                 molt,                                               & ! DME-MMC
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
                  sf_surface_physics                                 )
                                                                      
@@ -2004,6 +2009,8 @@ CONTAINS
                spec_z0,                                            & ! DME-MMC
                spec_ideal,                                         & ! DME-MMC
                itimestep,                                          & ! DME-MMC
+               ustt,                                               & ! DME-MMC
+               molt,                                               & ! DME-MMC
                ustm,ck,cka,cd,cda,isftcflx,iz0tlnd, scm_force_flux    )
                                                                       
 #if ( EM_CORE==1)
@@ -5576,6 +5583,8 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                      spec_hfx,                                     &    !JDM-MMC
                      spec_z0,                                      & ! DME-MMC
                      spec_ideal,                                   & ! DME-MMC
+                     ustt,                                         & ! DME-MMC
+                     molt,                                         & ! DME-MMC
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
                      sf_surface_physics                            )
      
@@ -5685,6 +5694,7 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
      REAL,     INTENT(IN)               ::      spec_hfx          !JDM-MMC
      REAL,     INTENT(IN)               ::      spec_z0           ! DME-MMC
      LOGICAL,  INTENT(IN)               ::      spec_ideal        ! DME-MMC
+     REAL,    DIMENSION( ims:ime, jms:jme ) , INTENT(INOUT)::   ustt, molt ! DME-MMC
 
      
 !--------------------------------------------------------------------
@@ -5836,6 +5846,8 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                  spec_z0,                                      & ! DME-MMC
                  spec_ideal,                                   & ! DME-MMC
                  itimestep,                                    & ! DME-MMC
+                 ustt,                                         & ! DME-MMC
+                 molt,                                         & ! DME-MMC
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd          )
      
 !
@@ -5931,6 +5943,8 @@ TICE2TSK_IF2COLD,XICE_THRESHOLD,                                   &
                  spec_z0,                                      & ! DME-MMC
                  spec_ideal,                                   & ! DME-MMC
                  itimestep,                                    & ! DME-MMC
+                 ustt,                                         & ! DME-MMC
+                 molt,                                         & ! DME-MMC
                  ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd )
     
 !


### PR DESCRIPTION
This code commit fixes a WRF issue affecting some surface layer variables on a parent domain at the time of initializing the nested domain. The attached figure demonstrates the problem and provides verification of the fix.

![initialization_d02_effect_on_d01_fix](https://user-images.githubusercontent.com/19294286/63890006-4ff5c280-c99f-11e9-8e5d-51b86161cbfa.jpg)

