### PR TITLE
bug-fix to prevent unintended latent heat flux

### DIFF
--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -510,7 +510,13 @@ CONTAINS
       DO 60 I=its,ite
         E1=SVP1*EXP(SVP2*(TGDSA(I)-SVPT0)/(TGDSA(I)-SVP3))                       
 !  for land points QSFC can come from previous time step
-        if(xland(i).gt.1.5.or.qsfc(i).le.0.0)QSFC(I)=EP2*E1/(PSFC(I)-E1)                                                 
+!!!JAS-MMC
+!!! Original qsfc(i).le.0.0 permits qsfc = 0.0 to lead to a non-zero QFX for 
+!!! dry idealized scenarios. Modifying to strictly .lt. here solves the problem. 
+!!!      if(xland(i).gt.1.5.or.qsfc(i).le.0.0)QSFC(I)=EP2*E1/(PSFC(I)-E1)                                                 
+        if(xland(i).gt.1.5.or.qsfc(i).lt.0.0)QSFC(I)=EP2*E1/(PSFC(I)-E1)   
+!!!JAS-MMC      
+                                              
 ! QGH CHANGED TO USE LOWEST-LEVEL AIR TEMP CONSISTENT WITH MYJSFC CHANGE
 ! Q2SAT = QGH IN LSM
         E1=SVP1*EXP(SVP2*(T1D(I)-SVPT0)/(T1D(I)-SVP3))                       


### PR DESCRIPTION
DESCRIPTION OF CHANGES: bug-fix to prevent unintended latent heat flux in idealized dry atmosphere scenarios under sf_sfclay_physics = 1

A2e-mmc scenario CBL_18Z-20z (intended dry, idealized CBL) was resulting non-zero latent heat flux, and consequently non-zero qvapor. This erroneously leads to much stronger convection for the targeted case than desired.

<img width="661" alt="Screen Shot 2019-09-23 at 4 17 24 PM" src="https://user-images.githubusercontent.com/22982605/65467740-63ba0a80-de1f-11e9-93b2-2a408690f841.png">

By modifying an if condition to be strictly 'less than' rather than 'less than or equal' the problem is solved...

<img width="567" alt="Screen Shot 2019-09-23 at 4 58 22 PM" src="https://user-images.githubusercontent.com/22982605/65469097-6585cd00-de23-11e9-8c10-594d3183f1e5.png">


