### PR TITLE
Feature/bathymetry

### DIFF
--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -563,6 +563,7 @@ BENCH_START(surf_driver_tim)
      &        ,HUML=grid%huml, HVML=grid%hvml, F=grid%f                             &
      &        ,TMOML=grid%TMOML,ISWATER=iswater                                     &
      &        ,OML_RELAXATION_TIME=grid%OML_RELAXATION_TIME                         &
+     &        ,use_bathymetry=config_flags%use_bathymetry,water_depth=grid%water_depth & !PSH
      &        ,lakedepth2d=grid%lakedepth2d,    savedtke12d=grid%savedtke12d        &   
      &        ,snowdp2d=grid%snowdp2d,          h2osno2d=grid%h2osno2d              & !lake
      &        ,snl2d=grid%snl2d,                t_grnd2d=grid%t_grnd2d              &   

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -30,7 +30,9 @@ CONTAINS
                      itimestep,                                    & ! DME-MMC
                      ustt,                                         & ! DME-MMC
                      molt,                                         & ! DME-MMC
-                     ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux )
+                     ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
+                     use_bathymetry,water_depth,                   & ! PSH
+                     scm_force_flux                                )
      
 !-------------------------------------------------------------------
       IMPLICIT NONE
@@ -211,6 +213,8 @@ CONTAINS
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX, IZ0TLND
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
 
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     use_bathymetry ! PSH
+      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN)  :: water_depth ! PSH
 ! LOCAL VARS
 
       REAL,     DIMENSION( its:ite ) ::                       U1D, &
@@ -283,6 +287,7 @@ CONTAINS
                 GZ1OZ0(ims,j),WSPD(ims,j),BR(ims,j),ISFFLX,DX,     &
                 SVP1,SVP2,SVP3,SVPT0,EP1,EP2,KARMAN,EOMEG,STBOLT,  &
                 P1000mb,                                           &
+                use_bathymetry,water_depth(ims,j),                 & ! PSH
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
                 its,ite, jts,jte, kts,kte                          &
@@ -317,6 +322,7 @@ CONTAINS
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
                      P1000mb,                                      &
+                     use_bathymetry,water_depth,                   & ! PSH
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
@@ -382,6 +388,8 @@ CONTAINS
                                     
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
 
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     use_bathymetry ! PSH
+      REAL, OPTIONAL, DIMENSION( ims:ime ), INTENT(IN)  :: water_depth ! PSH
 ! MODULE-LOCAL VARIABLES, DEFINED IN SUBROUTINE SFCLAY
       REAL,     DIMENSION( its:ite ),  INTENT(IN   )   ::  dz8w1d
 

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -444,6 +444,7 @@ CONTAINS
 ! .... paj ...
 !
       REAL    :: zolzz,zol0
+      REAL    :: depth,depth_b ! PSH
 !     REAL    :: zolri,zolri2
 !     REAL    :: psih_stable,psim_stable,psih_unstable,psim_unstable
 !     REAL    :: psih_stable_full,psim_stable_full,psih_unstable_full,psim_unstable_full
@@ -1046,8 +1047,22 @@ CONTAINS
       DO 360 I=its,ite
         IF((XLAND(I)-1.5).GE.0)THEN                                            
 !         ZNT(I)=CZO*UST(I)*UST(I)/G+OZO                                   
+! PSH - formulation for depth-dependent roughness from
+! ... Jimenez and Dudhia, 2018
+          IF ( use_bathymetry .eq. 1 ) THEN
+            depth = water_depth(I) 
+            IF ( depth .lt. 10.0 ) THEN
+              depth = 10.0 
+            ELSEIF ( depth .gt. 100.0 ) THEN
+              depth = 100.0
+            ENDIF
+              
+            depth_b = 1 / 30.0 * log (1260.0 / depth)
+            ZNT(I)= exp((2.7 * UST(I) - 1.8 / depth_b) / (UST(I) + 0.17 / depth_b) )
+          ELSE
 ! Since V3.7 (ref: EC Physics document for Cy36r1)
-          ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
+              ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
+          ENDIF
 ! V3.9: Add limit as in isftcflx = 1,2
           ZNT(I)=MIN(ZNT(I),2.85e-3)
 ! COARE 3.5 (Edson et al. 2013)

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -1354,9 +1354,9 @@ CONTAINS
                                                                                tkmg3d,         &
                                                                                tkdry3d,        &
                                                                                tksatu3d
-    real,    dimension(ims:ime,jms:jme ),intent(in)                         :: lakedepth2d
     INTEGER , OPTIONAL , INTENT(IN)                            :: use_bathymetry ! PSH
     real, OPTIONAL , dimension(ims:ime,jms:jme ),intent(in)    :: water_depth ! PSH
+    real,    dimension(ims:ime,jms:jme ),intent(in)                         :: lakedepth2d
 #if (EM_CORE==1)
     real ,    dimension(ims:ime,jms:jme )  ::  lakemask       
 !    INTEGER  :: lakeflag
@@ -2014,7 +2014,9 @@ CONTAINS
                itimestep,                                          & ! DME-MMC
                ustt,                                               & ! DME-MMC
                molt,                                               & ! DME-MMC
-               ustm,ck,cka,cd,cda,isftcflx,iz0tlnd, scm_force_flux    )
+               ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
+               use_bathymetry,water_depth,                         & ! PSH
+               scm_force_flux                                      )
                                                                       
 #if ( EM_CORE==1)
            DO j = j_start(ij),j_end(ij)
@@ -5764,7 +5766,8 @@ CONTAINS
                  itimestep,                                    & ! DME-MMC
                  ustt,                                         & ! DME-MMC
                  molt,                                         & ! DME-MMC
-                 ustm,ck,cka,cd,cda,isftcflx,iz0tlnd          )
+                 ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
+                 use_bathymetry,water_depth                    ) ! PSH
      
 !
 !Restore land-point values calculated by SSiB (fds 12/2010)
@@ -5861,7 +5864,8 @@ CONTAINS
                  itimestep,                                    & ! DME-MMC
                  ustt,                                         & ! DME-MMC
                  molt,                                         & ! DME-MMC
-                 ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd )
+                 ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd, &
+                 use_bathymetry,water_depth                    ) ! PSH
     
 !
      DO j = JTS , JTE

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -1993,6 +1993,7 @@ CONTAINS
                  ustt,                                               & ! DME-MMC
                  molt,                                               & ! DME-MMC
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
+                 use_bathymetry,water_depth,                         & ! PSH
                  sf_surface_physics                                 )
                                                                      
          ELSE
@@ -5498,6 +5499,7 @@ CONTAINS
                      ustt,                                         & ! DME-MMC
                      molt,                                         & ! DME-MMC
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
+                     use_bathymetry,water_depth,                   & ! PSH
                      sf_surface_physics                            )
      
      USE module_sf_sfclayrev
@@ -5577,6 +5579,8 @@ CONTAINS
                INTENT(INOUT)   ::                            ustm
 
      INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX,IZ0TLND
+     INTEGER,  OPTIONAL,  INTENT(IN )   ::     use_bathymetry ! PSH
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ) , INTENT(IN ) :: water_depth ! PSH
 
 !--------------------------------------------------------------------
 !    New for wrapper

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -90,6 +90,7 @@ CONTAINS
 #if (EM_CORE==1)
      &          ,ch,fgdp,dfgdp,vdfg,grav_settling                       & ! Katata - fog dep
 #endif
+     &          ,use_bathymetry,water_depth                             & ! PSH
      &          ,lakedepth2d,  savedtke12d,  snowdp2d,   h2osno2d       & !lake
      &          ,snl2d,        t_grnd2d,     t_lake3d,   lake_icefrac3d & !lake
      &          ,z_lake3d,     dz_lake3d,    t_soisno3d, h2osoi_ice3d   & !lake
@@ -1354,6 +1355,8 @@ CONTAINS
                                                                                tkdry3d,        &
                                                                                tksatu3d
     real,    dimension(ims:ime,jms:jme ),intent(in)                         :: lakedepth2d
+    INTEGER , OPTIONAL , INTENT(IN)                            :: use_bathymetry ! PSH
+    real, OPTIONAL , dimension(ims:ime,jms:jme ),intent(in)    :: water_depth ! PSH
 #if (EM_CORE==1)
     real ,    dimension(ims:ime,jms:jme )  ::  lakemask       
 !    INTEGER  :: lakeflag


### PR DESCRIPTION
Adding depth-dependent roughness calculation into sfclayrev scheme. To use, set "use_bathymetry" in &physics to 1 (max_domains). Note - you must have bathymetry data available for this - this requires WPS changes.