### PR TITLE
Add Jimenez depth dependent roughness to MYJ

### DIFF
--- a/phys/module_sf_myjsfc.F
+++ b/phys/module_sf_myjsfc.F
@@ -74,7 +74,7 @@ CONTAINS
      &                 ,QGH,CPM,CT                                     &
      &                 ,U10,V10,T02,TH02,TSHLTR,TH10,Q02,QSHLTR,Q10,PSHLTR          &
      &                 ,P1000mb,U10E,V10E                              &
-     &                 ,USE_BATHYMETRY,WATER_DEPTH                     &
+     &                 ,use_bathymetry,water_depth                     &
      &                 ,IDS,IDE,JDS,JDE,KDS,KDE                        &
      &                 ,IMS,IME,JMS,JME,KMS,KME                        &
      &                 ,ITS,ITE,JTS,JTE,KTS,KTE)
@@ -427,6 +427,9 @@ CONTAINS
      &       ,TERM1,RLOW,WSTAR,XLT02,XLT024,XLT10            &
      &       ,XLT104,XLU10,XLU104,XU10,XU104,ZT02,ZT10,ZTAT02,ZTAT10   &
      &       ,ZTAU,ZTAU10,ZU10,ZUUZ
+
+      REAL    :: depth,depth_b ! PSH
+
 !----------------------------------------------------------------------
 !**********************************************************************
 !----------------------------------------------------------------------
@@ -454,7 +457,21 @@ CONTAINS
 !----------------------------------------------------------------------
         DO ITR=1,ITRMX
 !----------------------------------------------------------------------
-          Z0=MAX(USTFC*USTAR*USTAR,1.59E-5)
+
+          IF ( use_bathymetry .eq. 1 ) THEN
+            depth = water_depth
+            IF ( depth .lt. 10.0 ) THEN
+             depth = 10.0
+            ELSEIF ( depth .gt. 100.0 ) THEN
+              depth = 100.0
+            ENDIF
+
+            depth_b = 1 / 30.0 * log (1260.0 / depth)
+            Z0 = exp((2.7 * USTAR - 1.8 / depth_b) / (USTAR + 0.17 / depth_b) )
+            Z0 = MIN(Z0,0.1)
+          ELSE
+            Z0=MAX(USTFC*USTAR*USTAR,1.59E-5)
+          ENDIF
 !
 !***  VISCOUS SUBLAYER, JANJIC MWR 1994
 !

--- a/phys/module_sf_myjsfc.F
+++ b/phys/module_sf_myjsfc.F
@@ -74,6 +74,7 @@ CONTAINS
      &                 ,QGH,CPM,CT                                     &
      &                 ,U10,V10,T02,TH02,TSHLTR,TH10,Q02,QSHLTR,Q10,PSHLTR          &
      &                 ,P1000mb,U10E,V10E                              &
+     &                 ,USE_BATHYMETRY,WATER_DEPTH                     &
      &                 ,IDS,IDE,JDS,JDE,KDS,KDE                        &
      &                 ,IMS,IME,JMS,JME,KMS,KME                        &
      &                 ,ITS,ITE,JTS,JTE,KTS,KTE)
@@ -121,6 +122,9 @@ CONTAINS
      &                                              ,QGH
 !
       REAL,INTENT(IN) :: P1000mb
+
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     use_bathymetry ! PSH
+      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ) , INTENT(IN ) :: water_depth ! PSH
 !----------------------------------------------------------------------
 !***
 !***  LOCAL VARIABLES
@@ -317,6 +321,7 @@ CONTAINS
      &               ,U10(I,J),V10(I,J),TSHLTR(I,J),TH10(I,J)          &
      &               ,QSHLTR(I,J),Q10(I,J),PSHLTR(I,J)                 &
      &               ,U10E(I,J),V10E(I,J)                              &
+     &               ,USE_BATHYMETRY,WATER_DEPTH(I,J)                  & ! PSH
      &               ,IDS,IDE,JDS,JDE,KDS,KDE                          &
      &               ,IMS,IME,JMS,JME,KMS,KME                          &
      &               ,ITS,ITE,JTS,JTE,KTS,KTE,i,j,ZHK(LMH+1))
@@ -367,6 +372,7 @@ CONTAINS
      &                 ,ZSL,PLOW                                       &
      &                 ,U10,V10,TH02,TH10,Q02,Q10,PSHLTR               &
      &                 ,U10E,V10E                                      &
+     &                 ,use_bathymetry,water_depth                     &
      &                 ,IDS,IDE,JDS,JDE,KDS,KDE                        &
      &                 ,IMS,IME,JMS,JME,KMS,KME                        &
      &                 ,ITS,ITE,JTS,JTE,KTS,KTE,i,j,ZSFC)
@@ -396,6 +402,9 @@ CONTAINS
      &                   ,TH02,TH10,U10,V10,U10E,V10E
 !
       REAL,INTENT(INOUT) :: AKHS,AKMS,QZ0,THZ0,USTAR,UZ0,VZ0,Z0,QS
+
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     use_bathymetry ! PSH
+      REAL, OPTIONAL,  INTENT(IN ) :: water_depth ! PSH
 !----------------------------------------------------------------------
 !***
 !***  LOCAL VARIABLES

--- a/phys/module_sf_myjsfc.F
+++ b/phys/module_sf_myjsfc.F
@@ -5,6 +5,7 @@
 !----------------------------------------------------------------------
 !
       USE MODULE_MODEL_CONSTANTS
+      USE module_sf_sfclayrev, ONLY : depth_dependent_z0
 #ifdef DM_PARALLEL
       USE MODULE_DM, ONLY : WRF_DM_MAXVAL
 #endif
@@ -459,16 +460,17 @@ CONTAINS
 !----------------------------------------------------------------------
 
           IF ( use_bathymetry .eq. 1 ) THEN
-            depth = water_depth
-            IF ( depth .lt. 10.0 ) THEN
-             depth = 10.0
-            ELSEIF ( depth .gt. 100.0 ) THEN
-              depth = 100.0
-            ENDIF
-
-            depth_b = 1 / 30.0 * log (1260.0 / depth)
-            Z0 = exp((2.7 * USTAR - 1.8 / depth_b) / (USTAR + 0.17 / depth_b) )
-            Z0 = MIN(Z0,0.1)
+            Z0=depth_dependent_z0(water_depth,Z0,USTAR)
+!            depth = water_depth
+!            IF ( depth .lt. 10.0 ) THEN
+!             depth = 10.0
+!            ELSEIF ( depth .gt. 100.0 ) THEN
+!              depth = 100.0
+!            ENDIF
+!
+!            depth_b = 1 / 30.0 * log (1260.0 / depth)
+!            Z0 = exp((2.7 * USTAR - 1.8 / depth_b) / (USTAR + 0.17 / depth_b) )
+!            Z0 = MIN(Z0,0.1)
           ELSE
             Z0=MAX(USTFC*USTAR*USTAR,1.59E-5)
           ENDIF

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -1290,13 +1290,14 @@ CONTAINS
 
      function depth_dependent_z0(water_depth,z0,UST)
      real :: depth_b
+     real :: effective_depth
         IF ( water_depth .lt. 10.0 ) THEN
-          water_depth = 10.0 
+          effective_depth = 10.0 
         ELSEIF ( water_depth .gt. 100.0 ) THEN
-          water_depth = 100.0
+          effective_depth = 100.0
         ENDIF
               
-        depth_b = 1 / 30.0 * log (1260.0 / water_depth)
+        depth_b = 1 / 30.0 * log (1260.0 / effective_depth)
         depth_dependent_z0 = exp((2.7 * ust - 1.8 / depth_b) / (ust + 0.17 / depth_b) )
         depth_dependent_z0 = MIN(z0,0.1)     
     return

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -994,16 +994,17 @@ CONTAINS
 ! PSH - formulation for depth-dependent roughness from
 ! ... Jimenez and Dudhia, 2018
           IF ( use_bathymetry .eq. 1 ) THEN
-            depth = water_depth(I) 
-            IF ( depth .lt. 10.0 ) THEN
-              depth = 10.0 
-            ELSEIF ( depth .gt. 100.0 ) THEN
-              depth = 100.0
-            ENDIF
-              
-            depth_b = 1 / 30.0 * log (1260.0 / depth)
-            ZNT(I)= exp((2.7 * UST(I) - 1.8 / depth_b) / (UST(I) + 0.17 / depth_b) )
-            ZNT(I)=MIN(ZNT(I),0.1)    
+             ZNT(I) = depth_dependent_z0(water_depth(I),ZNT(I),UST(I))
+!            depth = water_depth(I) 
+!            IF ( depth .lt. 10.0 ) THEN
+!              depth = 10.0 
+!            ELSEIF ( depth .gt. 100.0 ) THEN
+!              depth = 100.0
+!            ENDIF
+!              
+!            depth_b = 1 / 30.0 * log (1260.0 / depth)
+!            ZNT(I)= exp((2.7 * UST(I) - 1.8 / depth_b) / (UST(I) + 0.17 / depth_b) )
+!            ZNT(I)=MIN(ZNT(I),0.1)    
           ELSE
 ! Since V3.7 (ref: EC Physics document for Cy36r1)
               ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
@@ -1287,6 +1288,19 @@ CONTAINS
       return
       end function
 
+     function depth_dependent_z0(water_depth,z0,UST)
+     real :: depth_b
+        IF ( water_depth .lt. 10.0 ) THEN
+          water_depth = 10.0 
+        ELSEIF ( water_depth .gt. 100.0 ) THEN
+          water_depth = 100.0
+        ENDIF
+              
+        depth_b = 1 / 30.0 * log (1260.0 / water_depth)
+        depth_dependent_z0 = exp((2.7 * ust - 1.8 / depth_b) / (ust + 0.17 / depth_b) )
+        depth_dependent_z0 = MIN(z0,0.1)     
+    return
+    end function
 !-------------------------------------------------------------------          
 
 END MODULE module_sf_sfclayrev

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -24,12 +24,6 @@ CONTAINS
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
-                     spec_hfx,                                     & !JDM-MMC
-                     spec_z0,                                      & ! DME-MMC
-                     spec_ideal,                                   & ! DME-MMC
-                     itimestep,                                    & ! DME-MMC
-                     ustt,                                         & ! DME-MMC
-                     molt,                                         & ! DME-MMC
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
                      use_bathymetry,water_depth,                   & ! PSH
                      scm_force_flux                                )

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -2092,12 +2092,6 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                ids,ide, jds,jde, kds,kde,                          &
                ims,ime, jms,jme, kms,kme,                          &
                i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte, &
-               spec_hfx,                                              &   !JDM-MMC            
-               spec_z0,                                            & ! DME-MMC
-               spec_ideal,                                         & ! DME-MMC
-               itimestep,                                          & ! DME-MMC
-               ustt,                                               & ! DME-MMC
-               molt,                                               & ! DME-MMC
                ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,                &
                use_bathymetry,water_depth,                         & ! PSH
                scm_force_flux                                      )
@@ -5833,12 +5827,6 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                  ids,ide, jds,jde, kds,kde,                    &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    &
-                 spec_hfx,                                     &   !JDM-MMC
-                 spec_z0,                                      & ! DME-MMC
-                 spec_ideal,                                   & ! DME-MMC
-                 itimestep,                                    & ! DME-MMC
-                 ustt,                                         & ! DME-MMC
-                 molt,                                         & ! DME-MMC
                  ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
                  use_bathymetry,water_depth                    ) ! PSH
      
@@ -5931,12 +5919,6 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                  ids,ide, jds,jde, kds,kde,                    &
                  ims,ime, jms,jme, kms,kme,                    &
                  its,ite, jts,jte, kts,kte,                    & ! 0
-                 spec_hfx,                                     &            !JDM-MMC
-                 spec_z0,                                      & ! DME-MMC
-                 spec_ideal,                                   & ! DME-MMC
-                 itimestep,                                    & ! DME-MMC
-                 ustt,                                         & ! DME-MMC
-                 molt,                                         & ! DME-MMC
                  ustm_sea,ck_sea,cka_sea,cd_sea,cda_sea,isftcflx,iz0tlnd, &
                  use_bathymetry,water_depth                    ) ! PSH
     

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -2174,6 +2174,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                 chs,chs2,cqs2,hfx,qfx,lh,flhc,flqc,qgh,cpm,ct,       &
                 u10,v10,t2,th2,tshltr,th10,q2,qshltr,q10,pshltr,               &
                 p1000mb,u10e,v10e,                                   &
+                use_bathymetry,water_depth,                          & ! PSH
                 ids,ide, jds,jde, kds,kde,                           &
                 ims,ime, jms,jme, kms,kme,                           &
                 i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte    )
@@ -2191,6 +2192,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
               chs,chs2,cqs2,hfx,qfx,lh,flhc,flqc,qgh,cpm,ct,       &
               u10,v10,t2,th2,tshltr,th10,q2,qshltr,q10,pshltr,               &
               p1000mb,u10e,v10e,                                   &
+              use_bathymetry,water_depth,                          & ! PSH
               ids,ide, jds,jde, kds,kde,                           &
               ims,ime, jms,jme, kms,kme,                           &
               i_start(ij),i_end(ij), j_start(ij),j_end(ij), kts,kte    )

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -4259,6 +4259,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
         &     QGH,CPM,CT,                                 &
         &     U10,V10,T02,TH02,TSHLTR,TH10,Q02,QSHLTR,Q10,PSHLTR,          &
         &     P1000,U10E,V10E,                            &
+        &     use_bathymetry,water_depth,              & !PSH
         &     IDS,IDE,JDS,JDE,KDS,KDE,                        &
         &     IMS,IME,JMS,JME,KMS,KME,                        &
         &     ITS,ITE,JTS,JTE,KTS,KTE )
@@ -4348,6 +4349,8 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
           &                IMS,IME,JMS,JME,KMS,KME,       &
           &                ITS,ITE,JTS,JTE,KTS,KTE
 
+    INTEGER , OPTIONAL , INTENT(IN)                            :: use_bathymetry ! PSH
+    real, OPTIONAL , dimension(ims:ime,jms:jme ),intent(in)    :: water_depth ! PSH
 
      ! Local
      INTEGER :: i
@@ -4496,6 +4499,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
           &        TH02, TSHLTR, TH10, Q02,                        &  ! 0,0,0,0,
           &        QSHLTR, Q10, PSHLTR,                            &  ! 0,0,0,
           &        P1000, U10E, V10E,                              &  ! I
+          &        use_bathymetry,water_depth,                     & ! PSH
           &        ids,ide, jds,jde, kds,kde,                      &
           &        ims,ime, jms,jme, kms,kme,                      &
           &        its,ite, jts,jte, kts,kte    )
@@ -4550,6 +4554,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
           &        FLQC_SEA, QGH_SEA, CPM_SEA, CT_SEA, U10_SEA, V10_SEA, T02_SEA, TH02_SEA,    & ! 0,0,0,0,0,0,0,0,
           &        TSHLTR_SEA, TH10_SEA, Q02_SEA, QSHLTR_SEA, Q10_SEA, PSHLTR_SEA,             & ! 0,0,0,0,0,0,
           &        p1000, u10e_sea,  v10e_sea,                                                 & ! I
+          &        use_bathymetry,water_depth,                     & ! PSH
           &        ids,ide, jds,jde, kds,kde,                                                  &
           &        ims,ime, jms,jme, kms,kme,                                                  &
           &        its,ite, jts,jte, kts,kte    )


### PR DESCRIPTION
The Jiménez depth dependent roughness scheme is added to the MYJ surface layer parameterization. It is separated into a module so that further additions should be nearly trivial moving forward. I tested this with short runs with both YSU and MYJ PBL schemes with and without depth dependent roughness. Differences between YSU w/ Charnock and YSU w/ Jiménez were nearly identical to differences between MYJ w/ Charnock and MYJ w/ Jiménez meaning the code is acting in the same fashion between the two PBL schemes.