### PR TITLE
Adding two functionalitites: 1 Ability to output horizontal slices at…

### DIFF
--- a/Registry/registry.dimspec
+++ b/Registry/registry.dimspec
@@ -12,6 +12,7 @@ ifdef DA_CORE=0
 dimspec    stoclev 2     namelist=num_stoch_levels         z     num_stoch_levels
 dimspec    j       3     standard_domain                   y     south_north
 dimspec    k       2     standard_domain                   z     bottom_top
+dimspec    nslices 2     namelist=num_slices               z     num_slices
 endif
 
 ifdef DA_CORE=1

--- a/Registry/registry.em_shared_collection
+++ b/Registry/registry.em_shared_collection
@@ -29,3 +29,5 @@ include registry.trad_fields
 include registry.tsout
 include registry.cell_pert
 include registry.mom_pert
+include registry.scpm_jdm
+include registry.slices

--- a/Registry/registry.scpm_jdm
+++ b/Registry/registry.scpm_jdm
@@ -1,0 +1,11 @@
+state   real    pert_t   ikj    misc            1       -       rh      "pert_t"        ""      "K"
+state   real    prttms   k      misc            1       -       r       "prttms"        ""      "s"
+state   real    prtdt    k      misc            1       -       r       "prtdt"         ""      "s"
+state   real    prtk     k      misc            1       -       r       "prtk"         ""      "s"
+state   real    prtz     -      misc            1       -       r       "prtz"          ""      "m"
+state   integer prtnk    -      misc            1       -       r       "prtnk"         ""      ""
+state   integer prtseed  k      misc            1       -       r       "prtseed"       ""      ""
+state   real    m_pblh   ij     misc            1       -       rhdf    "m_pblh"       "PBL height for stoch. LES inflow perts" "m"
+
+rconfig	integer scpm_jdm_opt   	namelist,dynamics       max_domains     0       -       "Option to use stoch LES inflow perts, 0 is off"
+rconfig	integer m_pblh_opt    	namelist,dynamics       max_domains     0       -       "1 to calculate mesoscale pblh and pass to LES for stoch LES inflow perts, 0 is off"

--- a/Registry/registry.slices
+++ b/Registry/registry.slices
@@ -1,0 +1,20 @@
+# registry.slices
+#
+# 2D horizontal slice output, J. Mirocha (LLNL) and P. Hawbecker (NCAR), January 2021
+#
+
+state    real       slices_z       {nslices}          misc         1     -     h      "slices_z"       "heights of output slices"  "m"    
+
+state    real       slices_u       i{nslices}j        misc         1     -     h      "slices_u"       "2D slices of u"            "m s-1"
+state    real       slices_v       i{nslices}j        misc         1     -     h      "slices_v"       "2D slices of v"            "m s-1"
+state    real       slices_w       i{nslices}j        misc         1     -     h      "slices_w"       "2D slices of w"            "m s-1"    
+state    real       slices_t       i{nslices}j        misc         1     -     h      "slices_t"       "2D slices of T"            "K"    
+
+rconfig  integer    slice_opt      namelist,dynamics  max_domains  0           -      "slice_opt"      "1 to output slices"        " "
+
+rconfig  integer    num_slices     namelist,dynamics  1            1           h      "num_slices"     "Number of slices"          " "
+
+rconfig  real       slice_heights  namelist,dynamics  max_eta      -1.0        -      "slice_heights"  "Heights of slices"         " "
+
+package  no_slices  slice_opt==0   -                 - 
+package  slices     slice_opt==1   -                 state:slices_z,slices_u,slices_v,slices_w,slices_t

--- a/dyn_em/Makefile
+++ b/dyn_em/Makefile
@@ -22,11 +22,13 @@ MODULES =                 		\
         module_first_rk_step_part2.o    \
         module_avgflx_em.o              \
 	module_sfs_nba.o		\
+        module_scpm_jdm.o               \
         module_convtrans_prep.o         \
 	module_sfs_driver.o		\
 	module_stoch.o			\
 	module_after_all_rk_steps.o	\
         module_tsout.o                  \
+        module_horizontal_slices.o      \
         module_cellpert.o                  \
 	$(CASE_MODULE)
 

--- a/dyn_em/depend.dyn_em
+++ b/dyn_em/depend.dyn_em
@@ -263,6 +263,7 @@ solve_em.o:     module_small_step_em.o \
                 module_avgflx_em.o              \
 		module_polarfft.o \
                 module_tsout.o   \
+                module_horizontal_slices.o   \
 		../frame/module_domain.o \
 		../frame/module_configure.o  \
 		../frame/module_driver_constants.o \
@@ -302,6 +303,7 @@ module_first_rk_step_part2.o : \
                 module_bc_em.o         \
                 module_stoch.o         \
 		module_sfs_driver.o \
+                module_scpm_jdm.o   \
 		module_big_step_utilities_em.o \
 		../frame/module_domain.o \
 		../frame/module_state_description.o \
@@ -326,9 +328,15 @@ adapt_timestep_em.o: \
 		../frame/module_configure.o  \
 		../frame/module_dm.o
 
+module_scpm_jdm.o: \
+		../share/module_model_constants.o \
+		../frame/module_dm.o
+
 module_tsout.o: \
 		../share/module_model_constants.o
 
+module_horizontal_slices.o: \
+                ../share/module_model_constants.o
 
 #		../chem/module_chem_utilities.o \
 # 		../chem/module_input_chem_data.o

--- a/dyn_em/module_first_rk_step_part2.F
+++ b/dyn_em/module_first_rk_step_part2.F
@@ -61,7 +61,7 @@ CONTAINS
 
     USE module_sfs_driver !JDM
     USE module_stoch, ONLY : update_stoch_ten, perturb_physics_tend,RAND_PERT_UPDATE
-
+    USE module_scpm_jdm
 
     IMPLICIT NONE
 
@@ -371,6 +371,57 @@ BENCH_START(comp_diff_metrics_tim)
          ENDDO
          !$OMP END PARALLEL DO
 BENCH_END(comp_diff_metrics_tim)
+
+!JDM Perturbations
+
+
+IF ( ( config_flags%m_pblh_opt .EQ. 1 ) .AND. ( config_flags%km_opt .EQ. 4 ) ) THEN   
+
+         !$OMP PARALLEL DO   &
+         !$OMP PRIVATE ( ij )
+         DO ij = 1 , grid%num_tiles
+
+           CALL force_down_meso_pblh( grid%m_pblh, grid%pblh,            &   
+                                      ids, ide, jds, jde, kds, kde,      &
+                                      ims, ime, jms, jme, kms, kme,      &
+                                      grid%i_start(ij), grid%i_end(ij),  &
+                                      grid%j_start(ij), grid%j_end(ij),  &
+                                      k_start    , k_end                  )
+
+
+        ENDDO
+         !$OMP END PARALLEL DO
+
+ENDIF
+
+
+IF (  config_flags%scpm_jdm_opt .GT. 0 ) THEN   
+
+   IF (  config_flags%scpm_jdm_opt .EQ. 1 ) THEN   
+            !$OMP PARALLEL DO   &
+            !$OMP PRIVATE ( ij )
+            DO ij = 1 , grid%num_tiles
+
+              CALL calc_scpm_jdm_t ( config_flags%scpm_jdm_opt,                  &
+                                     config_flags%m_pblh_opt,                    &
+                                     grid%prttms, grid%prtdt, grid%prtnk,        &
+                                     grid%prtz, grid%prtseed, grid%pert_t,       &  
+                                     grid%m_pblh,                                & 
+                                     grid%t_2, grid%u_2, grid%v_2, grid%rdz,     &
+                                     grid%dx, grid%dt,                           & 
+                                     ids, ide, jds, jde, kds, kde,               &
+                                     ims, ime, jms, jme, kms, kme,               &
+                                     grid%i_start(ij), grid%i_end(ij),           &
+                                     grid%j_start(ij), grid%j_end(ij),           &
+                                     k_start    , k_end                          )
+
+            ENDDO
+            !$OMP END PARALLEL DO
+
+   ENDIF
+
+ENDIF
+
 
 #ifdef DM_PARALLEL
 #  include "HALO_EM_TKE_C.inc"

--- a/dyn_em/module_horizontal_slices.F
+++ b/dyn_em/module_horizontal_slices.F
@@ -1,0 +1,136 @@
+!WRF
+!
+MODULE module_horizontal_slices
+
+USE module_model_constants
+
+CONTAINS
+
+SUBROUTINE compute_horizontal_slices( slices_u, slices_v,             &
+                                      slices_w, slices_t, slices_z,   &
+                                      u, v, w, t, z, z_at_w, ht,      &
+                                      num_slices,                     &
+                                      slice_heights,                  &
+                                      ids, ide, jds, jde, kds, kde,   &
+                                      ims, ime, jms, jme, kms, kme,   &
+                                      its, ite, jts, jte, kts, kte      )
+
+!=======================================================================
+!
+!  This subroutine calculates num_slices of horizontal planes of 
+!  u, v, w, and t, interpolated to  slice_heights, for output.
+!
+!  J. Mirocha (LLNL) and P. Hawbecker (NCAR), January, 2021
+!
+!======================================================================= 
+
+   IMPLICIT NONE
+
+   REAL, DIMENSION(ims:ime,1:num_slices,jms:jme), INTENT( OUT ) :: slices_u, slices_v, &
+                                                                   slices_w, slices_t
+
+   REAL, DIMENSION(1:num_slices), INTENT( OUT ) :: slices_z
+   
+   REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(  IN ) :: u, v, w, t, z, z_at_w
+
+   REAL, DIMENSION(ims:ime,jms:jme), INTENT(  IN ) :: ht
+   
+   INTEGER, INTENT(  IN ) :: num_slices
+   
+   REAL , DIMENSION (1:num_slices), INTENT( IN )  :: slice_heights
+   
+   INTEGER , INTENT( IN  ) :: ids, ide, jds, jde, kds, kde, &
+                              ims, ime, jms, jme, kms, kme, &
+                              its, ite, jts, jte, kts, kte
+
+   ! local variables
+   
+   INTEGER :: i, j, k, k_slice
+
+   REAL :: d_z, d_1, d_2, fac_1, fac_2
+   REAL :: slice_height_abs
+   REAL :: u_m_1, u_m_2, v_m_1, v_m_2
+   
+!-----------------------------------------------------------------------
+! Executable code starts here
+!
+
+   DO k = 1, num_slices
+ 
+     slices_z(k) = slice_heights(k)
+     
+   END DO
+
+   
+   DO k_slice = 1, num_slices
+
+!      print*,k_slice,slice_heights(k_slice)
+
+      DO i = its, MIN(ite,ide-1)
+         DO j = jts, MIN(jte,jde-1)
+
+            slice_height_abs = slice_heights(k_slice) + ht(i,j)
+            
+            DO k = kts+1, MIN(kte,kde-1)
+               
+               IF ( z_at_w(i,k,j) .GE. slice_height_abs ) THEN
+
+                   d_z = z_at_w(i,k,j) - z_at_w(i,k-1,j)
+                   d_2 = z_at_w(i,k,j) - slice_height_abs
+                   d_1 = slice_height_abs - z_at_w(i,k-1,j)
+                   fac_2 = d_2/d_z
+                   fac_1 = d_1/d_z
+             
+                   slices_w(i,k_slice,j) = fac_2*w(i,k-1,j) + fac_1*w(i,k,j)
+
+!                   IF ( (i .EQ. its+2) .AND. (j .EQ. jts+2) )print*,k,fac_1*z_at_w(i,k,j)+fac_2*z_at_w(i,k-1,j)
+                   
+                   GOTO 1
+               
+               ENDIF
+
+            END DO !k
+
+1 CONTINUE
+
+            DO k = kts+1, MIN(kte,kde-1)
+            
+               IF ( z(i,k,j) .GE. slice_height_abs ) THEN
+
+                  d_z = z(i,k,j) - z(i,k-1,j)
+                  d_2 = z(i,k,j) - slice_height_abs
+                  d_1 = slice_height_abs - z(i,k-1,j)
+
+                  fac_2 = d_2/d_z
+                  fac_1 = d_1/d_z
+               
+                  u_m_2 = 0.5*(u(i+1,k,j) + u(i,k,j) ) ! u at cell center level k
+                  u_m_1 = 0.5*(u(i+1,k-1,j) + u(i,k-1,j) ) ! u at cell center level k-1
+                  v_m_2 = 0.5*(v(i,k,j+1) + v(i,k,j) ) ! v at cell center level k
+                  v_m_1 = 0.5*(v(i,k-1,j+1) + v(i,k-1,j) ) ! v at cell center level k-1
+
+                  slices_u(i,k_slice,j) = fac_2*u_m_1 + fac_1*u_m_2
+                  slices_v(i,k_slice,j) = fac_2*v_m_1 + fac_1*v_m_2
+                  slices_t(i,k_slice,j) = fac_2*t(i,k-1,j) + fac_1*t(i,k,j)
+
+!                   IF ( (i .EQ. its+2) .AND. (j .EQ. jts+2) )print*,k,fac_1*z(i,k,j)+fac_2*z(i,k-1,j)
+                  
+                  GOTO 2
+               
+               ENDIF
+
+            END DO !k
+         
+2       CONTINUE
+            
+         END DO
+      END DO
+   
+   END DO !k_slice
+   
+   RETURN
+
+END SUBROUTINE compute_horizontal_slices
+
+  
+END MODULE module_horizontal_slices

--- a/dyn_em/module_scpm_jdm.F
+++ b/dyn_em/module_scpm_jdm.F
@@ -1,0 +1,649 @@
+! WRF:MODEL_LAYER:PHYSICS
+ 
+    MODULE module_scpm_jdm
+
+    USE module_model_constants    
+
+#ifdef DM_PARALLEL
+    USE module_dm
+#endif
+
+    
+    CONTAINS
+
+!!=======================================================================
+
+    SUBROUTINE force_down_meso_pblh( m_pblh, pblh,                        &
+                                     ids, ide, jds, jde, kds, kde,        &
+                                     ims, ime, jms, jme, kms, kme,        &
+                                     its, ite, jts, jte, kts, kte         )
+
+!-----------------------------------------------------------------------
+!
+! Assign pbl height to m_pblh array to be forced down for nested LES
+!
+!
+    IMPLICIT NONE
+
+    INTEGER, INTENT( IN )  &
+    :: ids, ide, jds, jde, kds, kde,  &
+       ims, ime, jms, jme, kms, kme,  &
+       its, ite, jts, jte, kts, kte
+
+    REAL , DIMENSION( ims:ime, jms:jme ), INTENT( IN  ) :: pblh
+    REAL , DIMENSION( ims:ime, jms:jme ), INTENT( OUT ) :: m_pblh
+    INTEGER :: itimestep
+    INTEGER :: i,j
+         
+
+    DO j = jts, jte
+       DO i = its, ite
+
+          m_pblh(i,j) = pblh(i,j)
+
+       END DO
+    END DO
+ 
+!    print*,'in m_pblh, m_pblh(its,jts)',m_pblh(its,jts)   
+
+    END SUBROUTINE force_down_meso_pblh
+
+!=======================================================================
+ 
+    SUBROUTINE calc_scpm_jdm_t( les_pert_opt,                      &
+                            m_pblh_opt,                        &
+                            prttms, prtdt, prtnk,              &
+                            prtz, prtseed, pert_t,             &
+                            mpblh,                             &
+                            t, u, v, rdz,                      &
+                            dx, dt,                            &
+                            ids, ide, jds, jde, kds, kde,      &
+                            ims, ime, jms, jme, kms, kme,      &
+                            its, ite, jts, jte, kts, kte       )
+
+!-----------------------------------------------------------------------
+
+    IMPLICIT NONE
+
+#ifdef DM_PARALLEL
+    INCLUDE 'mpif.h'
+#endif
+
+    INTEGER, INTENT( IN    )  &
+    :: ids, ide, jds, jde, kds, kde,  &
+       ims, ime, jms, jme, kms, kme,  &
+       its, ite, jts, jte, kts, kte
+
+    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( INOUT ) :: t         ! potential temperature                 [k]
+    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( INOUT ) :: pert_t    ! potential temperature perturbation    [k]
+    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( IN    ) :: u         ! zonal wind component                  [m/s]
+    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( IN    ) :: v         ! meridional wind component             [m/s]
+    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT( IN    ) :: rdz       ! inverse vertical grid spacing         [1/m]
+    REAL, DIMENSION( ims:ime, jms:jme ),          INTENT( IN    ) :: mpblh    ! PBL height from messoscale PBL scheme [m]
+    REAL, DIMENSION( kms:kme ),                   INTENT( INOUT ) :: prttms    ! time since last perturbation refresh  [s]
+    REAL, DIMENSION( kms:kme ),                   INTENT( INOUT ) :: prtdt     ! time scale to refresh perturbations   [s]
+    
+    INTEGER, DIMENSION( kms:kme ),                INTENT( INOUT ) :: prtseed   ! 1D variable to store variable-length seed array
+
+    INTEGER, INTENT( IN    ) :: les_pert_opt           ! which perturbation option to use
+    INTEGER, INTENT( IN    ) :: m_pblh_opt             ! whether to use (1) mesoscale PBL height or not (0)
+    REAL,    INTENT( INOUT ) :: prtz                   ! height over swhich to apply perturbations
+    INTEGER, INTENT( INOUT ) :: prtnk                  ! number of vertical grid cells over which to apply perturbations
+    REAL,    INTENT( IN    ) :: dt                     ! model time step
+    REAL,    INTENT( IN    ) :: dx                     ! horizontal grid spacing
+
+    REAL, DIMENSION( its:ite, kts:kte, jts:jte ) :: z  ! height above surface at midpoint levels   
+    REAL, DIMENSION( its:ite, jts:jte ) :: pblh        ! height above surface at midpoint levels   
+    
+    INTEGER :: i, j, k, big_k, slab_k, m            ! loop variables
+    INTEGER :: i_start, i_end, j_start, j_end       ! patch endpoints
+    INTEGER :: i_seed                               ! size of seed
+    INTEGER :: seedsum                              ! variable for summing the seed
+    INTEGER :: ngc_h, ngc_v                         ! number of gridcells in i and j directions for each perturbation cell
+    INTEGER :: ni, nj                               ! number of perturbation cells in i and j directions (for random number query)
+    INTEGER :: ncells_h
+    INTEGER :: n_slabs_k                            ! number of perturbations cells in horizontal and vertical directions
+    INTEGER :: k_slab_start, k_slab_end             ! vertical indices over which to apply perturbations
+    INTEGER :: north, south, east, west, nsew       !logic for identification of LBs to perturb
+    INTEGER :: k_geo                                ! k index at which h_wg is computed
+    REAL    :: h_geo                                ! height at which to estimate ug
+    REAL    :: ugeosum, vgeosum
+    REAL    :: ugeolbsum, vgeolbsum
+    REAL    :: ugeolbavg, vgeolbavg, wsgeolbavg
+    REAL    :: uslabsum, vslabsum 
+    REAL    :: uslablbsum, vslablbsum
+    REAL    :: uslablbavg, vslablbavg, wsslablbavg  !
+    REAL    :: anglelbavg 
+    REAL    :: num_pts_in_sum                       ! Variables for computing averages
+    REAL    :: tpertmag                             ! Magnitude of thermal perturbation
+    REAL    :: dz                                   ! Depth
+    REAL    :: pblh_def 
+    REAL    :: sf                                  ! scaling factor for perturbation profile
+    REAL    :: sf2 
+    REAL    :: ek_opt = 0.20                        ! optimal value of the perturbation Ekman #
+    REAL    :: pio2 = piconst/2.0
+    REAL    :: pio4 = piconst/4.0    
+    REAL    :: max_pblh, max_pert_z
+    REAL    :: min_slab_z
+    REAl    :: sca_fac = 1.0
+    REAL    :: lambda
+    INTEGER :: idum, jdum
+   
+    
+    REAL    :: counter
+    
+    INTEGER, dimension( : ), allocatable :: seed              ! random number seed
+    REAL, dimension( :, : ), allocatable :: pxs,pxe,pys,pye   ! random number arrays for each lateral boundary
+  
+#ifdef DM_PARALLEL
+    INTEGER :: ierr
+    INTEGER :: tag
+    INTEGER :: master
+    INTEGER :: status(MPI_STATUS_SIZE)
+#endif
+
+#ifdef DM_PARALLEL
+    master = 0
+    tag    = 0
+#endif
+
+! END DECLARATIONS
+
+
+    ngc_h = 8      !perturbation cell width in horizontal directions in i,j-index values
+    ngc_v = 1      !perturbation cell thickness in vertical direction in k-index values
+    ncells_h = 3   !number of perturbation cells in horizontal direction
+    
+    n_slabs_k = kde/ngc_v
+    
+    pblh_def  = 100.0 !1000.0  !default pbl height if not using m_pblh_opt
+    
+    ! LOOP VER ALL VERTICAL PERTURBATION SLABS TO SEE IF IT IS TIME TO START OR REFRESH
+
+    lambda = 0.875
+    
+    DO slab_k = 1, n_slabs_k     !Outer k-loop over number of vertical perturbation slabs
+       
+       prttms(slab_k) = prttms(slab_k) + dt
+       
+       ! print*,slab_k, prttms(slab_k), prtdt(slab_k)
+
+       
+       IF ( prttms(slab_k) .GE. prtdt(slab_k) ) THEN !prdt should be zero at startup
+          
+          prttms(slab_k) = dt
+
+          prtdt(slab_k) = 300.0 !CHECK EVERY 5 MINUTES IF PBLH HAS GROWN
+          
+          print*,'Computing new perturbations, slab_k = ',slab_k
+          
+          ! ONLY COMPUTE/APPLY PERTURBATIONS FOR SLABS WITH A GLOBAL Z-VALUE BELOW GLOBAL PBLH MAXIMUM
+          
+          i_start = its
+          i_end   = MIN(ite,ide)
+          j_start = jts
+          j_end   = MIN(jte,jde)
+          
+          IF (m_pblh_opt .EQ. 0 ) THEN !SET PBLH TO A DESIRED VALUE
+             
+             DO j=j_start, j_end
+                DO i=i_start, i_end
+                   pblh(i,j) = pblh_def
+                END DO
+             END DO
+             
+          ENDIF
+          
+          IF (m_pblh_opt .EQ. 1 ) THEN !SET PBLH TO A DESIRED VALUE
+             
+             DO j=j_start, j_end
+                DO i=i_start, i_end
+                   pblh(i,j) = mpblh(i,j)
+                END DO
+             END DO
+             
+          ENDIF
+          
+          ! COMPUTE THE LOCAL HEIGHT ABOVE THE SURFACE AT EACH GRID POINT
+          
+          DO j=j_start, j_end
+             DO i=i_start, i_end
+                z(i,kts,j)= 1.0/rdz(i,kts,j)
+                DO k=kts+1,kde-1  
+                   z(i,k,j) = z(i,k-1,j) + 1.0/rdz(i,k,j)
+                END DO
+             END DO
+          END DO
+          
+          k_slab_start = MIN( (slab_k - 1)*ngc_v + 1,kde-1 )         !LOWEST K-VALUE IN SLAB
+          k_slab_end = MIN( k_slab_start + ngc_v - 1, kde-1 )  !HIGHEST K-VALUE IN SLAB    
+          
+          max_pblh = MAXVAL( pblh(i_start:i_end,j_start:j_end) )        
+          min_slab_z = MINVAL(z(i_start:i_end,k_slab_start,j_start:j_end))
+          
+          !print*,'Here 1 '
+          !print*,'k_slab_start,k_slab_end ',k_slab_start,k_slab_end
+          !print*,'max_pblh,min_slab_z ',max_pblh,min_slab_z
+
+          idum = 1
+          jdum = 1
+          
+#ifdef DM_PARALLEL
+          
+          CALL wrf_dm_maxval_real(max_pblh,idum,jdum)
+          
+          CALL wrf_dm_minval_real(min_slab_z,idum,jdum)
+          
+#endif
+          
+          !print*,'Here 2 '
+          !print*,'max_pblh,min_slab_z ',max_pblh,min_slab_z
+
+
+          max_pert_z = max_pblh !*0.666666
+!          max_pert_z = 200.0
+!          
+           IF ( min_slab_z .LE. max_pert_z ) THEN  
+!          IF ( min_slab_z .LE. max_pblh ) THEN  !IF ANY K VALUE IN THE SLAB IS BELOW THE MAXIMUM PBL HEIGHT
+             !THEN THAT GRID POINT MAY REQUIRE A PERTURBATION
+           
+            
+             ! NOW THAT WE HAVE PBLH, CALCULATE UG, VG DOMAIN AVERAGE
+             
+             h_geo = 1.10*max_pblh
+
+             ugeosum = 0.0
+             vgeosum = 0.0
+             uslabsum = 0.0
+             vslabsum = 0.0
+             num_pts_in_sum = 0.0
+             
+             
+             ! print*,'a,h_geo ',h_geo 
+             
+             DO j=j_start, j_end
+                
+                DO i=i_start, i_end
+                   
+                   DO k=kts,kde-2
+                      
+                      IF ( ( z(i,k,j) .LE. h_geo ) .AND. ( z(i,k+1,j) .GT. h_geo ) )  k_geo = k
+                      
+                   END DO
+                   
+                   ugeosum = ugeosum + u(i,k_geo,j)
+                   vgeosum = vgeosum + v(i,k_geo,j)
+                   uslabsum = uslabsum + u(i,k_slab_end,j)
+                   vslabsum = vslabsum + v(i,k_slab_end,j)
+                   
+                   num_pts_in_sum = num_pts_in_sum + 1.0
+                   
+                END DO
+                
+             END DO
+             
+             !print*,' Here 3',k_geo,num_pts_in_sum 
+             
+             
+             !print*,'ugeosum ',ugeosum
+             !print*,'vgeosum ',vgeosum
+             !print*,'uslabsum ',uslabsum
+             !print*,'vslabsum ',vslabsum
+             
+             
+!GOTO 200
+             
+#ifdef DM_PARALLEL
+             
+             ugeolbsum  = wrf_dm_sum_real(ugeosum)
+             
+             vgeolbsum  = wrf_dm_sum_real(vgeosum)
+             
+             uslablbsum  = wrf_dm_sum_real(uslabsum)
+             
+             vslablbsum  = wrf_dm_sum_real(vslabsum)
+             
+             counter = wrf_dm_sum_real(num_pts_in_sum)
+             
+#endif
+             
+             !print*,' Here 4 counter',counter
+             
+             ugeolbavg = ugeolbsum/counter
+             
+             vgeolbavg = vgeolbsum/counter
+             
+             uslablbavg = uslablbsum/counter
+             
+             vslablbavg = vslablbsum/counter
+             
+             
+             wsgeolbavg = sqrt( ugeolbavg*ugeolbavg + vgeolbavg*vgeolbavg )
+             
+             wsslablbavg = sqrt( uslablbavg*uslablbavg + vslablbavg*vslablbavg )
+             
+             
+             anglelbavg = atan( abs( uslablbavg )/abs( vslablbavg ) )
+             
+             IF (anglelbavg .GT. pio4 ) anglelbavg = pio2 - anglelbavg 
+             
+             !print*,'ugeolbavg ',ugeolbavg
+             !print*,'vgeolbavg ',vgeolbavg
+             !print*,'uslablbsum ',uslablbavg
+             !print*,'vslablbavg ',vslablbavg
+             
+             !print*,'anglelbavg ',anglelbavg
+             
+             north = 0
+             east = 0
+             south = 0
+             west = 0
+             
+             IF ( ugeolbsum .GT. 0.0 ) west = 1
+             IF ( ugeolbsum .LT. 0.0 ) east = 1
+             IF ( vgeolbsum .GT. 0.0 ) south = 1
+             IF ( vgeolbsum .LT. 0.0 ) north = 1
+             
+             ! print*,'uwsgpsumdsum,vwsgpsumdsum',uwsgpsumdsum,vwsgpsumdsum
+             ! print*,'n, s, e, w',north,south,east,west     
+             
+             !
+             ! Uncomment to select your own inflow/outflow boundaries
+             !
+             ! north = 0
+             ! east = 0
+             ! south = 0
+             ! west = 1
+             
+             ! print*,'Applying perturbations to the following boundary(ies):'
+             ! IF (north .EQ. 1) print*,'north'
+             ! IF (south .EQ. 1) print*,'south'
+             ! IF (east .EQ. 1) print*,'east'
+             ! IF (west .EQ. 1) print*,'west'
+             
+             nsew = 0
+             IF  ( (west + east) .EQ. 2) nsew = 1
+             IF  ( (north + south) .EQ. 2) nsew = 1
+             IF  ( (north + south + east + west) .EQ. 1) nsew = 1
+             IF  ( (north + south + east + west) .EQ. 4) nsew = 1
+             IF  ( (north + south + east + west) .EQ. 3) nsew = 0
+             
+             IF (wsslablbavg .EQ. 0.0) THEN !Prevent division by zero
+                
+                print*,'something wrong in calc_scpm_jdm_t'
+                STOP
+                
+             ENDIF
+             
+             tpertmag = sca_fac*(wsgeolbavg*wsgeolbavg)/(ek_opt*cp)
+!             tpertmag = 0.25
+
+             
+            ! print*,'tpertmag',tpertmag
+             
+             ! prtdt = 0.5*(1.0/cos(anglespavgdavg))*ngc_h*ncells_h*dx/wsspavgdavg 
+             
+             prtdt(slab_k) = (lambda/cos(anglelbavg))*ngc_h*ncells_h*dx/wsslablbavg
+
+!JDM             prtdt(slab_k) = 100.0
+             
+             ! print*,'anglespavgdavg',anglespavgdavg*180.0/piconst
+             
+             !print*,'prtdt',prtdt(slab_k)
+
+             
+             ! CALCULATE (NEW) PERTURBATIONS ===============================================================================
+             
+             ni = (ide-1)/ngc_h 
+             nj = (jde-1)/ngc_h  
+             
+             ! print*,'ni,nj',ni,nj
+             
+             ! Allocate perturbation array for each lateral boundary 
+             
+             ALLOCATE( pxs(1:nj,1:ncells_h) )
+             ALLOCATE( pxe(1:nj,1:ncells_h) )
+             ALLOCATE( pys(1:ni,1:ncells_h) )
+             ALLOCATE( pye(1:ni,1:ncells_h) )
+             
+             CALL RANDOM_SEED(size=i_seed)  ! 1. Get the size of the seed, each processor.
+             
+             ALLOCATE( seed(1:i_seed) )     ! 2. Allocate an array to hold the seed, each processor.
+             
+#ifdef DM_PARALLEL
+             
+             IF ( mytask .EQ. master ) THEN
+                
+                seedsum = 0                     ! 3a. Sum the stored seed (up to i_seed) to see if it has been assigned.
+                DO k = 1,i_seed             !     If so, now master has the current prtseed value in seed.
+                   seed(k) = prtseed(k)
+                   seedsum = seedsum + seed(k)
+                END DO
+                
+                IF (seedsum .EQ. 0 ) THEN       !3b. If the seed is empty, get the first seed, which is now only on master.
+                   
+                   print*,'calling random seed for first time'   
+                   CALL RANDOM_SEED(get=seed)
+                   
+                ENDIF
+                
+             ENDIF
+             
+             CALL MPI_BCAST(seed,i_seed,MPI_REAL,master,MPI_COMM_WORLD,ierr) ! Broadcast seed from master to all
+             
+             ! print*,'seed',seed
+             
+             CALL RANDOM_SEED(put=seed) !Use same seed value so all processors receive idential random numbers
+             
+             CALL RANDOM_NUMBER(pxs)
+             CALL RANDOM_NUMBER(pxe)
+             CALL RANDOM_NUMBER(pys)
+             CALL RANDOM_NUMBER(pye)
+             
+             ! CALL MPI_BARRIER(MPI_COMM_WORLD,ierr)
+             
+             IF ( mytask .EQ. master ) THEN! Must get a new seed and store into prtseed so the sequence at the next perturbation update begins with new seed. 
+                
+                CALL RANDOM_SEED(get=seed)
+                
+                DO k = 1,i_seed
+                   prtseed(k) = seed(k)
+                ENDDO!
+                
+             ENDIF
+             
+#endif
+             
+             
+             ! DO k = kts,kte  ! Zero out. Probably not necessary but good religion. 
+             !    DO j=j_start, j_end
+             !       DO i=i_start, i_end
+             !          pert_t(i,k,j) = 0.0
+             !       END DO
+             !    END DO
+             ! END DO
+             
+             sf = 1.0
+             !sf2 = 4.0*max_pblh/27.0 !maximum value of sf(z) = z*(1-z/h)^2 
+
+             IF ( west .EQ. 1 ) THEN
+                
+                IF (its .LE. ids + ngc_h*ncells_h) THEN 
+                   
+                   DO j = MAX(jts,jds + ngc_h*ncells_h*(west - south - nsew)), MIN(jte,jde - 1 - ngc_h*ncells_h*(west - north - nsew))
+                      
+                      ! print*,'j,((j-1)/ngc_h+1)',j,((j-1)/ngc_h+1)
+                      
+                      DO i = its, MIN(ite, ide-1)
+                         
+                         ! print*,'i,((i-1)/ngc_h+1)',i,((i-1)/ngc_h+1)
+                         
+                         m = (i-1)/ngc_h+1
+                         
+                         IF ( m .LE. ncells_h ) THEN
+                            
+                            DO k = k_slab_start, k_slab_end
+
+                               pert_t(i,k,j) =  (pxs(((j-1)/ngc_h+1),m)-0.5)*sf*2.0*tpertmag !Output variable only, for debugging.
+                               
+                               t(i,k,j) = t(i,k,j) + (pxs(((j-1)/ngc_h+1),m)-0.5)*sf*2.0*tpertmag
+                               
+                            END DO ! k
+                            
+                         ENDIF
+                         
+                      END DO ! i
+                      
+                   END DO! j
+                   
+                ENDIF
+                
+             ENDIF
+             
+             IF ( east .EQ. 1 ) THEN
+                
+                IF (ite .GE. ide - 1 - ngc_h*ncells_h) THEN 
+                   
+                   DO j = MAX(jts,jds + ngc_h*ncells_h*(east - south - nsew)), MIN(jte,jde - 1 - ngc_h*ncells_h*(east - north - nsew))
+                      
+                      DO i = MIN(ite, ide-1), its, -1
+                         
+                         m = (ide-i-1)/ngc_h+1
+                         
+                         IF ( m .LE. ncells_h ) THEN
+                            
+                            DO k = k_slab_start, k_slab_end
+
+!                               sf = MAX( (z(i,k,j)*(1.0-z(i,k,j)/max_pblh)**2)/sf2, 0.0 )
+!                               sf = MAX( cos(piconst*z(i,k,j)/(2*max_pblh))**2, 0.0 )
+!                               sf = MAX( (1.0-z(i,k,j)/max_pblh)**2, 0.0 )
+                               
+                               pert_t(i,k,j) = (pxe(((j-1)/ngc_h+1),m)-0.5)*sf*2.0*tpertmag
+                               
+                               t(i,k,j) = t(i,k,j) + (pxe(((j-1)/ngc_h+1),m)-0.5)*sf*2.0*tpertmag
+                               
+                            END DO ! k
+                            
+                         ENDIF
+                         
+                      END DO ! i
+                      
+                   END DO ! j
+                   
+                ENDIF
+                
+             ENDIF
+             
+             IF ( south .EQ. 1 ) THEN
+                
+                IF (jts .LE. jds + ngc_h*ncells_h) THEN 
+                   
+                   DO i = MAX(its,ids + ngc_h*ncells_h*(south - west - nsew)), MIN(ite,ide - 1 - ngc_h*ncells_h*(south - east - nsew))
+                      
+                      DO j = jts, MIN(jte, jde-1)
+                         
+                         m = (j-1)/ngc_h+1
+                         
+                         IF ( m .LE. ncells_h ) THEN
+                            
+                            DO k = k_slab_start, k_slab_end
+                               
+                               ! print*,'i,(i-1)/ngc_h+1,j,m,pys',i,(i-1)/ngc_h+1,j,m
+                               ! print*,'k,n,pys',k,n,pys(((i-1)/ngc_h+1),n,m)
+                                
+                               pert_t(i,k,j) = (pys(((i-1)/ngc_h+1),m)-0.5)*sf*2.0*tpertmag
+                               
+                               t(i,k,j) = t(i,k,j) + (pys(((i-1)/ngc_h+1),m)-0.5)*sf*2.0*tpertmag
+                               
+                            END DO ! k
+                            
+                         ENDIF
+                         
+                      END DO ! i
+                      
+                   END DO ! j
+                   
+                ENDIF
+                
+             ENDIF
+             
+             IF ( north .EQ. 1 ) THEN
+                
+                IF (jte .GE. jde - 1 - ngc_h*ncells_h) THEN 
+                   
+                   DO i = MAX(its,ids + ngc_h*ncells_h*(north - west - nsew)), MIN(ite,ide - 1 - ngc_h*ncells_h*(north - east - nsew))
+                      
+                      DO j = MIN(jte, jde-1),jts,-1
+                         
+                         m = (jde-j-1)/ngc_h+1
+                         
+                         IF ( m .LE. ncells_h ) THEN
+                            
+                            DO k = k_slab_start, k_slab_end
+
+                               pert_t(i,k,j) = (pye(((i-1)/ngc_h+1),m)-0.5)*sf*2.0*tpertmag
+                               
+                               t(i,k,j) = t(i,k,j) + (pye(((i-1)/ngc_h+1),m)-0.5)*sf*2.0*tpertmag
+                               
+                            END DO ! k
+                            
+                         ENDIF
+                         
+                      END DO ! i
+                      
+                   END DO ! j
+                   
+                ENDIF
+                
+             ENDIF
+             
+             DEALLOCATE(seed)
+             
+             DEALLOCATE( pxs )
+             DEALLOCATE( pxe )
+             DEALLOCATE( pys )
+             DEALLOCATE( pye )
+             
+200          CONTINUE
+             
+
+!             print*,'min_slab_z .GE. max_pblh ',slab_k
+             
+          END IF ! IF ( min_slab_z .GE. max_pblh ) 
+
+!200          CONTINUE
+          
+!          print*,'prttms(slab_k) .GE. prtdt(slab_k) ',slab_k
+          
+       END IF !(  prttms(slab_k) .GE. prtdt(slab_k) ) THEN
+              
+!       print*,'Big outer k-loop  ',slab_k
+   
+    END DO !Big outer k-loop over number of vertical perturbation slabs
+    
+    !       DO k=kts,kte - 1  
+    !!          sf(k) = (z(itilemid,k,jtilemid)*(1.0-z(itilemid,k,jtilemid)/prtz)**2)/sf2
+    !          sf(k) = 1.0 !jdm TEST 09142017
+    !          IF ( z(itilemid,k,jtilemid) .LE. prtz ) prtnk = k
+    !          IF ( z(itilemid,k,jtilemid) .LE. h_wg ) k_wg = k
+    !          IF ( z(itilemid,k,jtilemid) .GT. prtz ) sf(k) = 0.0
+    !!          print*,'k,z(itilemid,k,jtilemid),sf(k)',k,z(itilemid,k,jtilemid),sf(k)
+    !       END DO
+    
+   
+!=================================================================================
+
+END SUBROUTINE calc_scpm_jdm_t
+
+!=======================================================================
+
+
+
+!=======================================================================
+!=======================================================================
+!=======================================================================
+
+    END MODULE module_scpm_jdm
+
+!=======================================================================
+!=======================================================================

--- a/dyn_em/module_tsout.F
+++ b/dyn_em/module_tsout.F
@@ -6,12 +6,11 @@ USE module_model_constants
 
 CONTAINS
 
-SUBROUTINE compute_vertical_slice( u_slice, v_slice,                          &
-                                   w_slice, t_slice,                          &
-                                   u, v, w, t, z, z_at_w,                     &
-                                   hgt,                                       &
-                                   ph,phb,                                    &
-                                   slice_height,                              &
+SUBROUTINE compute_vertical_slice( slices_u, slices_v,                        &
+                                   slices_w, slices_t, slices_z,              &
+                                   u, v, w, t, z, z_at_w, ht,                 &
+                                   num_slices,                                &
+                                   slice_heights,                             &
                                    ids, ide, jds, jde, kds, kde,              &
                                    ims, ime, jms, jme, kms, kme,              &
                                    its, ite, jts, jte, kts, kte               )
@@ -24,14 +23,18 @@ SUBROUTINE compute_vertical_slice( u_slice, v_slice,                          &
 
    IMPLICIT NONE
 
-   REAL, DIMENSION(ims:ime,jms:jme), INTENT( OUT ) :: u_slice, v_slice, &
-                                                      w_slice, t_slice
+   REAL, DIMENSION(ims:ime,1:num_slices,jms:jme), INTENT( OUT ) :: slices_u, slices_v, &
+                                                                   slices_w, slices_t
+
+   REAL, DIMENSION(1:num_slices), INTENT( OUT ) :: slices_z
    
    REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(  IN ) :: u, v, w, t, z, z_at_w
-   REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(  IN ) :: ph,phb
-   REAL, DIMENSION(ims:ime,jms:jme), INTENT(  IN ) :: hgt
+
+   REAL, DIMENSION(ims:ime,jms:jme), INTENT(  IN ) :: ht
    
-   REAL, INTENT(  IN ) :: slice_height
+   INTEGER, INTENT(  IN ) :: num_slices
+   
+   REAL , DIMENSION (1:num_slices), INTENT( IN )  :: slice_heights
    
    INTEGER , INTENT( IN  ) :: ids, ide, jds, jde, kds, kde, &
                               ims, ime, jms, jme, kms, kme, &
@@ -39,111 +42,89 @@ SUBROUTINE compute_vertical_slice( u_slice, v_slice,                          &
 
    ! local variables
    
+   INTEGER :: i, j, k, k_slice
 
-   INTEGER :: i, j, k, k_max
-
-   REAL :: z_1, z_2, d_1, d_2, d_z, fac_1, fac_2
+   REAL :: d_z, d_1, d_2, fac_1, fac_2
    REAL :: slice_height_abs
    REAL :: u_m_1, u_m_2, v_m_1, v_m_2
-   REAL :: z_w_1,z_w_2
-
    
 !-----------------------------------------------------------------------
-! executable code starts here
+! Executable code starts here
 !
-   DO i = its, MIN(ite,ide-1)
-      DO j = jts, MIN(jte,jde-1)
 
-         DO k = kts+1, MIN(kte,kde-1)
-
-            z_2 =  z(i,k,j) ! slices are interpolated to cell centers
-            z_w_2 = 0.5*( z(i,k,j) + z(i,k+1,j) ) 
-
-            slice_height_abs = slice_height + hgt(i,j)
-
-
-            IF ( z_w_2 .GE. slice_height_abs ) THEN
-               z_w_1 = 0.5*(z(i,k-1,j) + z(i,k,j)) 
-
-               d_z = z_w_2 - z_w_1
-               d_2 = z_w_2 - slice_height_abs
-               d_1 = slice_height_abs - z_w_1
-               fac_2 = d_2/d_z
-               fac_1 = d_1/d_z
-               
-               w_slice(i,j) = fac_2*w(i,k-1,j) + fac_1*w(i,k,j)
-
-               GOTO 20
-               
-            ENDIF
-
-20       CONTINUE
-
-            IF ( z_2 .GE. slice_height_abs ) THEN
-               z_1 = z(i,k-1,j)
-
-               d_z = z_2 - z_1
-               d_2 = z_2 - slice_height_abs
-               d_1 = slice_height_abs - z_1
-               fac_2 = d_2/d_z
-               fac_1 = d_1/d_z
-               
-               u_m_2 = 0.5*(u(i+1,k,j) + u(i,k,j) ) ! u at cell center level k
-               u_m_1 = 0.5*(u(i+1,k-1,j) + u(i,k-1,j) ) ! u at cell center level k-1
-               v_m_2 = 0.5*(v(i,k,j+1) + v(i,k,j) ) ! v at cell center level k
-               v_m_1 = 0.5*(v(i,k-1,j+1) + v(i,k-1,j) ) ! v at cell center level k-1
-
-               u_slice(i,j) = fac_2*u_m_1 + fac_1*u_m_2
-               v_slice(i,j) = fac_2*v_m_1 + fac_1*v_m_2
-               t_slice(i,j) = fac_2*t(i,k-1,j) + fac_1*t(i,k,j)
-                
-               GOTO 30
-               
-            ENDIF
-
-         END DO
-
-30       CONTINUE
-         
-      END DO
-   END DO
-
-
-
-
-   DO i = its, MIN(ite,ide-1)
-      DO j = jts, MIN(jte,jde-1)
-
-         DO k = kts+1, MIN(kte,kde-1)
-
-            z_2 =  z(i,k,j) ! slices are interpolated to cell centers
-            z_w_2 = 0.5*( z(i,k,j) + z(i,k+1,j) ) 
-
-            slice_height_abs = slice_height + hgt(i,j)
-
-
-            IF ( z_w_2 .GE. slice_height_abs ) THEN
-               z_w_1 = 0.5*(z(i,k-1,j) + z(i,k,j)) 
-
-               d_z = z_w_2 - z_w_1
-               d_2 = z_w_2 - slice_height_abs
-               d_1 = slice_height_abs - z_w_1
-               fac_2 = d_2/d_z
-               fac_1 = d_1/d_z
-               
-               w_slice(i,j) = fac_2*w(i,k-1,j) + fac_1*w(i,k,j)
-
-               GOTO 40
-               
-            ENDIF
-
-         END DO
-
-40       CONTINUE
-         
-      END DO
-   END DO
+   DO k = 1, num_slices
+ 
+     slices_z(k) = slice_heights(k)
+!     print*,k,slice_heights(k)
      
+   END DO
+
+   
+   DO k_slice = 1, num_slices
+
+!      print*,k_slice,slice_heights(k_slice)
+
+      DO i = its, MIN(ite,ide-1)
+         DO j = jts, MIN(jte,jde-1)
+
+            slice_height_abs = slice_heights(k_slice) + ht(i,j)
+            
+            DO k = kts+1, MIN(kte,kde-1)
+               
+               IF ( z_at_w(i,k,j) .GE. slice_height_abs ) THEN
+
+                   d_z = z_at_w(i,k,j) - z_at_w(i,k-1,j)
+                   d_2 = z_at_w(i,k,j) - slice_height_abs
+                   d_1 = slice_height_abs - z_at_w(i,k-1,j)
+                   fac_2 = d_2/d_z
+                   fac_1 = d_1/d_z
+             
+                   slices_w(i,k_slice,j) = fac_2*w(i,k-1,j) + fac_1*w(i,k,j)
+
+!                   IF ( (i .EQ. its+2) .AND. (j .EQ. jts+2) )print*,k,fac_1*z_at_w(i,k,j)+fac_2*z_at_w(i,k-1,j)
+                   
+                   GOTO 1
+               
+               ENDIF
+
+            END DO !k
+
+1 CONTINUE
+
+            DO k = kts+1, MIN(kte,kde-1)
+            
+               IF ( z(i,k,j) .GE. slice_height_abs ) THEN
+
+                  d_z = z(i,k,j) - z(i,k-1,j)
+                  d_2 = z(i,k,j) - slice_height_abs
+                  d_1 = slice_height_abs - z(i,k-1,j)
+
+                  fac_2 = d_2/d_z
+                  fac_1 = d_1/d_z
+               
+                  u_m_2 = 0.5*(u(i+1,k,j) + u(i,k,j) ) ! u at cell center level k
+                  u_m_1 = 0.5*(u(i+1,k-1,j) + u(i,k-1,j) ) ! u at cell center level k-1
+                  v_m_2 = 0.5*(v(i,k,j+1) + v(i,k,j) ) ! v at cell center level k
+                  v_m_1 = 0.5*(v(i,k-1,j+1) + v(i,k-1,j) ) ! v at cell center level k-1
+
+                  slices_u(i,k_slice,j) = fac_2*u_m_1 + fac_1*u_m_2
+                  slices_v(i,k_slice,j) = fac_2*v_m_1 + fac_1*v_m_2
+                  slices_t(i,k_slice,j) = fac_2*t(i,k-1,j) + fac_1*t(i,k,j)
+
+!                   IF ( (i .EQ. its+2) .AND. (j .EQ. jts+2) )print*,k,fac_1*z(i,k,j)+fac_2*z(i,k-1,j)
+                  
+                  GOTO 2
+               
+               ENDIF
+
+            END DO !k
+         
+2       CONTINUE
+            
+         END DO
+      END DO
+   
+   END DO !k_slice
    
    RETURN
 

--- a/dyn_em/solve_em.F
+++ b/dyn_em/solve_em.F
@@ -78,8 +78,9 @@ SUBROUTINE solve_em ( grid , config_flags  &
    USE module_llxy, ONLY : proj_cassini
    USE module_avgflx_em, ONLY : zero_avgflx, upd_avgflx
    USE module_cpl, ONLY : coupler_on, cpl_settime, cpl_store_input
-   USE module_tsout !JDM-MMC
-   USE module_cellpert ! DME-MMC
+   USE module_tsout             !JDM-MMC
+   USE module_horizontal_slices !JDM-MMC
+   USE module_cellpert          ! DME-MMC
 
    IMPLICIT NONE
 
@@ -4838,25 +4839,24 @@ BENCH_END(bc_2d_tim)
    ! JDM-MMC BEGIN--------------------------------------------------------
    ! calculate vertical slices at specified heights above the surface.
 
-   IF ( config_flags%slice_height .GT. 0.0 ) THEN
+   IF ( config_flags%slice_opt .EQ. 1 ) THEN
 
     CALL wrf_debug ( 10 , ' call compute_vertical_slice' )
 
     !$OMP PARALLEL DO   &
     !$OMP PRIVATE ( ij )
     DO ij = 1 , grid%num_tiles
-       CALL compute_vertical_slice(grid%u_slice, grid%v_slice,             &
-                                   grid%w_slice, grid%t_slice,             &
-                                   grid%u_2, grid%v_2, grid%w_2, grid%t_2, &  
-                                   grid%z, grid%z_at_w,                    &
-                                   grid%ht,                                &!PSH
-                                   grid%ph_2,grid%phb,                     &!PSH
-                                   config_flags%slice_height,              &
-                                   ids, ide, jds, jde, kds, kde,           & 
-                                   ims, ime, jms, jme, kms, kme,           &
-                                   grid%i_start(ij), grid%i_end(ij),       &
-                                   grid%j_start(ij), grid%j_end(ij),       &
-                                   k_start, k_end                           )
+       CALL compute_horizontal_slices( grid%slices_u, grid%slices_v,                &
+                                       grid%slices_w, grid%slices_t, grid%slices_z, &
+                                       grid%u_2, grid%v_2, grid%w_2, grid%t_2,      &  
+                                       grid%z, grid%z_at_w, grid%ht,                &
+                                       config_flags%num_slices,                     &
+                                       model_config_rec%slice_heights,              &
+                                       ids, ide, jds, jde, kds, kde,                & 
+                                       ims, ime, jms, jme, kms, kme,                &
+                                       grid%i_start(ij), grid%i_end(ij),            &
+                                       grid%j_start(ij), grid%j_end(ij),            &
+                                       k_start, k_end                                 )
      
     END DO
     !$OMP END PARALLEL DO

--- a/phys/module_bl_ysu.F
+++ b/phys/module_bl_ysu.F
@@ -711,6 +711,7 @@ contains
        brint = (brcr(i)-brdn(i))/(brup(i)-brdn(i))
      endif
      hpbl(i) = za(i,k-1)+brint*(za(i,k)-za(i,k-1))
+
      if(hpbl(i).lt.zq(i,2)) kpbl(i) = 1
      if(kpbl(i).le.1) pblflg(i) = .false.
    enddo
@@ -1756,6 +1757,7 @@ contains
 
       wt=.5*TANH((zi - sbl_lim)/sbl_damp) + .5
       zi=PBLH_TKE*(1.-wt) + zi*wt
+
       
    END SUBROUTINE GET_PBLH
 ! ==================================================================


### PR DESCRIPTION
PURPOSE: Add horizontal slice output capability and alternate version of cell perturbation method

TYPE: new features

KEYWORDS: horizontal slices, cell perturbations

SOURCE: Jeff Mirocha, LLNL

DESCRIPTION OF CHANGES:
Added 1) capability to output 2D horizontal slices of u,v,t and w at an arbitrary number of arbitrary heights above the surface, specifiable in the namelist.input file at run time. Added 2) new version of cell perturbations with height-based refresh timescale and mesoscale PBL forcing. Uses new registry file  and new module dyn_em/module_scpm_jdm.F.

LIST OF MODIFIED FILES: 
For slices: Registry/registry.slices (new file), Registry/registry.dimspec, Registry/registry.em_shared_collection, dyn_em/module_horizontal_slices.F (new file), dyn_em/solve_em.F, dyn_em/Makefile, dyn_em/depend.dyn_em

For new scpm: Registry/registry.scpm_jdm, Registry/registry.em_shared_collection, dyn_em/module_scpm_jdm.F.,  dyn_em/module_first_rk_step_part2.F, dyn_em/Makefile, dyn_em/depend.dyn_em

TESTS CONDUCTED: 
1. Tested slices by comparing slices at interpolated heights to closest vertical level of the same variables. 
2. Tested SCPM by visual inspection of output (impact of perturbations on temperature and velocity).
