### PR TITLE
Feature/4mwinds

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -430,7 +430,6 @@ state    real   PSFC             ij     misc        1         -     i01rh01du   
 
 state    real   U10              ij     misc        1         -     irh01{22}{23}du     "U10"                "U at 10 M"         "m s-1"
 state    real   V10              ij     misc        1         -     irh01{22}{23}du     "V10"                "V at 10 M"         "m s-1"
-# PSH
 state    real   U4               ij     misc        1         -     rh          "U4"                 "U at 4 M"          "m s-1"
 state    real   V4               ij     misc        1         -     rh          "V4"                 "V at 4 M"          "m s-1"
 # LPI

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -430,6 +430,9 @@ state    real   PSFC             ij     misc        1         -     i01rh01du   
 
 state    real   U10              ij     misc        1         -     irh01{22}{23}du     "U10"                "U at 10 M"         "m s-1"
 state    real   V10              ij     misc        1         -     irh01{22}{23}du     "V10"                "V at 10 M"         "m s-1"
+# PSH
+state    real   U4               ij     misc        1         -     rh          "U4"                 "U at 4 M"          "m s-1"
+state    real   V4               ij     misc        1         -     rh          "V4"                 "V at 4 M"          "m s-1"
 # LPI
 state    real   LPI              ij     misc        1         -     rhdu   "LPI"                 "Lightning Potential Index"      "m^2 s-2"
 
@@ -837,6 +840,8 @@ state    real   ts_clw          ?!       misc      -         -      -        "TS
 state    real   ts_rainc        ?!       misc      -         -      -        "TS_RAINC"       "Cumulus precip"
 state    real   ts_rainnc       ?!       misc      -         -      -        "TS_RAINNC"      "Grid-scale precip"
 state    real   ts_ust          ?!       misc      -         -      -        "TS_UST"         "U-star"
+state    real   ts_u4           ?!       misc      -         -      -        "TS_U4"          "4m wind U-component, earth-relative"
+state    real   ts_v4           ?!       misc      -         -      -        "TS_V4"          "4m wind V-component, earth-relative"
 
 # Time series of vertical profile of U, V, GHT, THETA, QVAPOR, PRESSURE
 state    real   ts_u_profile   ?!k       misc      -         -      -        "TS_U_PROFILE"   "Wind u-Component, earth relative, vertical profile" "m/s"
@@ -3272,8 +3277,8 @@ package   icedepth_one   seaice_thickness_opt==1     -             state:icedept
 
 #Time series options for text output
 package   notseries             process_time_series==0                 -             -
-package   tseries               process_time_series==1                 -             state:ts_hour,ts_u,ts_v,ts_q,ts_t,ts_psfc,ts_glw,ts_gsw,ts_hfx,ts_qfx,ts_lh,ts_tsk,ts_tslb,ts_clw,ts_rainc,ts_rainnc,ts_ust,ts_u_profile,ts_v_profile,ts_gph_profile,ts_th_profile,ts_p_profile,ts_w_profile,ts_tke_profile
-package   tseries_add_solar     process_time_series==2                 -             state:ts_hour,ts_u,ts_v,ts_q,ts_t,ts_psfc,ts_glw,ts_gsw,ts_hfx,ts_qfx,ts_lh,ts_tsk,ts_tslb,ts_clw,ts_rainc,ts_rainnc,ts_ust,ts_u_profile,ts_v_profile,ts_gph_profile,ts_th_profile,ts_cldfrac2d,ts_wvp,ts_lwp,ts_iwp,ts_swp,ts_lwp_tot,ts_iwp_tot,ts_swp_tot,ts_re_qc,ts_re_qi,ts_re_qs,ts_re_qc_tot,ts_re_qi_tot,ts_re_qs_tot,ts_tau_qc,ts_tau_qi,ts_tau_qs,ts_tau_qc_tot,ts_tau_qi_tot,ts_tau_qs_tot,ts_cbaseht,ts_ctopht,ts_cbaseht_tot,ts_ctopht_tot,ts_clrnidx,ts_p_profile,ts_w_profile,ts_swdown,ts_swddni,ts_swddif,ts_swdownc,ts_swddnic,ts_swdown2,ts_swddni2,ts_swddif2,ts_swdownc2,ts_swddnic2
+package   tseries               process_time_series==1                 -             state:ts_hour,ts_u,ts_v,ts_q,ts_t,ts_psfc,ts_glw,ts_gsw,ts_hfx,ts_qfx,ts_lh,ts_tsk,ts_tslb,ts_clw,ts_rainc,ts_rainnc,ts_ust,ts_u4,ts_v4,ts_u_profile,ts_v_profile,ts_gph_profile,ts_th_profile,ts_p_profile,ts_w_profile,ts_tke_profile
+package   tseries_add_solar     process_time_series==2                 -             state:ts_hour,ts_u,ts_v,ts_q,ts_t,ts_psfc,ts_glw,ts_gsw,ts_hfx,ts_qfx,ts_lh,ts_tsk,ts_tslb,ts_clw,ts_rainc,ts_rainnc,ts_ust,ts_u4,ts_v4,ts_u_profile,ts_v_profile,ts_gph_profile,ts_th_profile,ts_cldfrac2d,ts_wvp,ts_lwp,ts_iwp,ts_swp,ts_lwp_tot,ts_iwp_tot,ts_swp_tot,ts_re_qc,ts_re_qi,ts_re_qs,ts_re_qc_tot,ts_re_qi_tot,ts_re_qs_tot,ts_tau_qc,ts_tau_qi,ts_tau_qs,ts_tau_qc_tot,ts_tau_qi_tot,ts_tau_qs_tot,ts_cbaseht,ts_ctopht,ts_cbaseht_tot,ts_ctopht_tot,ts_clrnidx,ts_p_profile,ts_w_profile,ts_swdown,ts_swddni,ts_swddif,ts_swdownc,ts_swddnic,ts_swdown2,ts_swddni2,ts_swddif2,ts_swdownc2,ts_swddnic2
 
 # WRF-HAILCAST
 state    real   HAILCAST_DHAIL1   ij     misc        1         -      r          "HAILCAST_DHAIL1"     "WRF-HAILCAST Hail Diameter, 1st rank order"     "mm"

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -591,6 +591,7 @@ BENCH_START(surf_driver_tim)
      &        ,UDRUNOFF=grid%udrunoff  ,UST=grid%ust       ,UZ0=grid%uz0            &
      &        ,U_FRAME=grid%u_frame    ,U_PHY=grid%u_phy   ,V10=grid%v10            &
      &        ,U10E=grid%u10e          ,V10E=grid%v10e                              &
+     &        ,U4=grid%u4              ,V4=grid%v4                                  & ! PSH
      &        ,UOCE=grid%uoce          ,VOCE=grid%voce                              &
      &        ,VEGFRA=grid%vegfra      ,VZ0=grid%vz0       ,V_FRAME=grid%v_frame    &
      &        ,V_PHY=grid%v_phy        ,WARM_RAIN=grid%warm_rain                    &

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -591,7 +591,7 @@ BENCH_START(surf_driver_tim)
      &        ,UDRUNOFF=grid%udrunoff  ,UST=grid%ust       ,UZ0=grid%uz0            &
      &        ,U_FRAME=grid%u_frame    ,U_PHY=grid%u_phy   ,V10=grid%v10            &
      &        ,U10E=grid%u10e          ,V10E=grid%v10e                              &
-     &        ,U4=grid%u4              ,V4=grid%v4                                  & ! PSH
+     &        ,U4=grid%u4              ,V4=grid%v4                                  & 
      &        ,UOCE=grid%uoce          ,VOCE=grid%voce                              &
      &        ,VEGFRA=grid%vegfra      ,VZ0=grid%vz0       ,V_FRAME=grid%v_frame    &
      &        ,V_PHY=grid%v_phy        ,WARM_RAIN=grid%warm_rain                    &

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -16,7 +16,7 @@ CONTAINS
                      ZNT,UST,PBLH,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH, &
                      FM,FH,                                        &
                      XLAND,HFX,QFX,LH,TSK,FLHC,FLQC,QGH,QSFC,RMOL, &
-                     U10,V10,U4,V4,TH2,T2,Q2,                      & ! PSH
+                     U10,V10,U4,V4,TH2,T2,Q2,                      &
                      GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
@@ -144,8 +144,8 @@ CONTAINS
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(OUT  )               ::                U10, &
                                                               V10, &
-                                                               U4, & ! PSH
-                                                               V4, & ! PSH
+                                                               U4, & 
+                                                               V4, & 
                                                               TH2, &
                                                                T2, &
                                                                Q2, &
@@ -236,7 +236,7 @@ CONTAINS
                 MOL(ims,j),REGIME(ims,j),PSIM(ims,j),PSIH(ims,j),  &
                 FM(ims,j),FH(ims,j),                               &
                 XLAND(ims,j),HFX(ims,j),QFX(ims,j),TSK(ims,j),     &
-                U10(ims,j),V10(ims,j),U4(ims,j),V4(ims,j),         & ! PSH
+                U10(ims,j),V10(ims,j),U4(ims,j),V4(ims,j),         & 
                 TH2(ims,j),T2(ims,j),                              &
                 Q2(ims,j),FLHC(ims,j),FLQC(ims,j),QGH(ims,j),      &
                 QSFC(ims,j),LH(ims,j),                             &
@@ -263,7 +263,7 @@ CONTAINS
                      CP,G,ROVCP,R,XLV,PSFCPA,CHS,CHS2,CQS2,CPM,PBLH,RMOL, &
                      ZNT,UST,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH,FM,FH,&
                      XLAND,HFX,QFX,TSK,                            &
-                     U10,V10,U4,V4,TH2,T2,Q2,FLHC,FLQC,QGH,        & ! PSH
+                     U10,V10,U4,V4,TH2,T2,Q2,FLHC,FLQC,QGH,        & 
                      QSFC,LH,GZ1OZ0,WSPD,BR,ISFFLX,DX,             &
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
@@ -328,7 +328,7 @@ CONTAINS
                                                               QGH
 
       REAL,     DIMENSION( ims:ime )                             , &
-                INTENT(OUT)     ::                  U10,V10,U4,V4, & ! PSH
+                INTENT(OUT)     ::                  U10,V10,U4,V4, & 
                                                 TH2,T2,Q2,QSFC,LH
 
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
@@ -361,8 +361,8 @@ CONTAINS
                                                            THX,QX, &
                                                             PSIH2, &
                                                             PSIM2, &
-                                                            PSIH4, & ! PSH
-                                                            PSIM4, & ! PSH
+                                                            PSIH4, & 
+                                                            PSIM4, & 
                                                            PSIH10, &
                                                            PSIM10, &
                                                            DENOMQ, &
@@ -370,7 +370,7 @@ CONTAINS
                                                           DENOMT2, &
                                                             WSPDI, &
                                                            GZ2OZ0, &
-                                                           GZ4OZ0, & ! PSH
+                                                           GZ4OZ0, & 
                                                            GZ10OZ0
 !
       REAL,     DIMENSION( its:ite )        ::                     &
@@ -385,15 +385,15 @@ CONTAINS
       INTEGER ::  N,I,K,KK,L,NZOL,NK,NZOL2,NZOL10
 
       REAL    ::  PL,THCON,TVCON,E1
-      REAL    ::  ZL,TSKV,DTHVDZ,DTHVM,VCONV,RZOL,RZOL2,RZOL10,ZOL2,ZOL4,ZOL10 ! PSH
-      REAL    ::  DTG,PSIX,DTTHX,PSIX10,PSIX4,PSIT,PSIT2,PSIQ,PSIQ2,PSIQ10 ! PSH
+      REAL    ::  ZL,TSKV,DTHVDZ,DTHVM,VCONV,RZOL,RZOL2,RZOL10,ZOL2,ZOL4,ZOL10 
+      REAL    ::  DTG,PSIX,DTTHX,PSIX10,PSIX4,PSIT,PSIT2,PSIQ,PSIQ2,PSIQ10 
       REAL    ::  FLUXC,VSGD,Z0Q,VISC,RESTAR,CZIL,GZ0OZQ,GZ0OZT
       REAL    ::  ZW, ZN1, ZN2
 !
 ! .... paj ...
 !
       REAL    :: zolzz,zol0
-      REAL    :: depth,depth_b ! PSH
+      REAL    :: depth,depth_b 
 !     REAL    :: zolri,zolri2
 !     REAL    :: psih_stable,psim_stable,psih_unstable,psim_unstable
 !     REAL    :: psih_stable_full,psim_stable_full,psih_unstable_full,psim_unstable_full
@@ -600,7 +600,7 @@ CONTAINS
 !
         zolzz=zol(I)*(za(I)+znt(I))/za(I) ! (z+z0/L
         zol10=zol(I)*(10.+znt(I))/za(I)   ! (10+z0)/L
-        zol4=zol(I)*(4.+znt(I))/za(I)     ! (4+z0)/L ! PSH
+        zol4=zol(I)*(4.+znt(I))/za(I)     ! (4+z0)/L 
         zol2=zol(I)*(2.+znt(I))/za(I)     ! (2+z0)/L
         zol0=zol(I)*znt(I)/za(I)          ! z0/L
         ZL2=(2.)/ZA(I)*ZOL(I)             ! 2/L      
@@ -630,8 +630,8 @@ CONTAINS
         psim2(I)=psim_stable(zol2)-psim_stable(zol0)
         psih2(I)=psih_stable(zol2)-psih_stable(zol0)
 !
-        psim4(I)=psim_stable(zol4)-psim_stable(zol0) ! PSH 
-        psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH 
+        psim4(I)=psim_stable(zol4)-psim_stable(zol0)  
+        psih4(I)=psih_stable(zol4)-psih_stable(zol0)  
 ! ... paj: preparations to compute PSIQ. Follows CB05+Carlson Boland JAM 1978.
 !
         pq(I)=psih_stable(zol(I))-psih_stable(zl)
@@ -653,8 +653,8 @@ CONTAINS
         PSIH10(I)=PSIM10(I)                                           
         PSIM2(I)=0.                                                  
         PSIH2(I)=PSIM2(I)                                           
-        PSIM4(I)=0.        ! PSH                                          
-        PSIH4(I)=PSIM4(I)  ! PSH                                         
+        PSIM4(I)=0.                                                  
+        PSIH4(I)=PSIM4(I)                                           
 !
 ! paj: preparations to compute PSIQ.
 !
@@ -683,8 +683,8 @@ CONTAINS
         psim2(I)=psim_unstable(zol2)-psim_unstable(zol0)
         psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
 !
-        psim4(I)=psim_unstable(zol4)-psim_unstable(zol0) ! PSH 
-        psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH 
+        psim4(I)=psim_unstable(zol4)-psim_unstable(zol0)  
+        psih4(I)=psih_unstable(zol4)-psih_unstable(zol0)  
 ! ... paj: preparations to compute PSIQ 
 !
         pq(I)=psih_unstable(zol(I))-psih_unstable(zl)
@@ -696,12 +696,12 @@ CONTAINS
         PSIH(I)=AMIN1(PSIH(I),0.9*GZ1OZ0(I))
         PSIM(I)=AMIN1(PSIM(I),0.9*GZ1OZ0(I))
         PSIH2(I)=AMIN1(PSIH2(I),0.9*GZ2OZ0(I))
-        PSIH4(I)=AMIN1(PSIH4(I),0.9*GZ4OZ0(I)) ! PSH
+        PSIH4(I)=AMIN1(PSIH4(I),0.9*GZ4OZ0(I)) 
         PSIM10(I)=AMIN1(PSIM10(I),0.9*GZ10OZ0(I))
 !
 ! AHW: mods to compute ck, cd
         PSIH10(I)=AMIN1(PSIH10(I),0.9*GZ10OZ0(I))
-        PSIH4(I)=AMIN1(PSIH4(I),0.9*GZ4OZ0(I)) ! PSH
+        PSIH4(I)=AMIN1(PSIH4(I),0.9*GZ4OZ0(I)) 
 
         RMOL(I) = ZOL(I)/ZA(I)  
 
@@ -713,7 +713,7 @@ CONTAINS
       DO 330 I=its,ite
         DTG=THX(I)-THGB(I)                                                   
         PSIX=GZ1OZ0(I)-PSIM(I)                                                   
-        PSIX4=GZ4OZ0(I)-PSIM4(I) ! PSH
+        PSIX4=GZ4OZ0(I)-PSIM4(I) 
         PSIX10=GZ10OZ0(I)-PSIM10(I)
 
 !     LOWER LIMIT ADDED TO PREVENT LARGE FLHC IN SOIL MODEL
@@ -748,24 +748,24 @@ CONTAINS
            zolzz=zol(I)*(za(I)+z0t)/za(I)    ! (z+z0t)/L
            zol10=zol(I)*(10.+z0t)/za(I)   ! (10+z0t)/L
            zol2=zol(I)*(2.+z0t)/za(I)     ! (2+z0t)/L
-           zol4=zol(I)*(4.+z0t)/za(I)     ! (4+z0t)/L ! PSH
+           zol4=zol(I)*(4.+z0t)/za(I)     ! (4+z0t)/L 
            zol0=zol(I)*z0t/za(I)          ! z0t/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
-              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) 
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
-                psih4(I)=0. ! PSH
+                psih4(I)=0. 
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
-                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) 
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -774,25 +774,25 @@ CONTAINS
 
            zolzz=zol(I)*(za(I)+z0q)/za(I)    ! (z+z0q)/L
            zol10=zol(I)*(10.+z0q)/za(I)   ! (10+z0q)/L
-           zol4=zol(I)*(4.+z0q)/za(I)     ! (4+z0q)/L ! PSH
+           zol4=zol(I)*(4.+z0q)/za(I)     ! (4+z0q)/L 
            zol2=zol(I)*(2.+z0q)/za(I)     ! (2+z0q)/L
            zol0=zol(I)*z0q/za(I)          ! z0q/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
-              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) 
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
-                psih4(I)=0. ! PSH
+                psih4(I)=0. 
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
-                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) 
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -815,25 +815,25 @@ CONTAINS
 !
            zolzz=zol(I)*(za(I)+z0q)/za(I)    ! (z+z0q)/L
            zol10=zol(I)*(10.+z0q)/za(I)   ! (10+z0q)/L
-           zol4=zol(I)*(4.+z0q)/za(I)     ! (4+z0q)/L ! PSH
+           zol4=zol(I)*(4.+z0q)/za(I)     ! (4+z0q)/L 
            zol2=zol(I)*(2.+z0q)/za(I)     ! (2+z0q)/L
            zol0=zol(I)*z0q/za(I)          ! z0q/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
-              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) 
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
-                psih4(I)=0. ! PSH
+                psih4(I)=0. 
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
-                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) 
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -861,25 +861,25 @@ CONTAINS
 !
            zolzz=zol(I)*(za(I)+z0t)/za(I)    ! (z+z0t)/L
            zol10=zol(I)*(10.+z0t)/za(I)   ! (10+z0t)/L
-           zol4=zol(I)*(4.+z0t)/za(I)     ! (4+z0t)/L ! PSH
+           zol4=zol(I)*(4.+z0t)/za(I)     ! (4+z0t)/L 
            zol2=zol(I)*(2.+z0t)/za(I)     ! (2+z0t)/L
            zol0=zol(I)*z0t/za(I)          ! z0t/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
-              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) 
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
-                psih4(I)=0. ! PSH
+                psih4(I)=0. 
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
-                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) 
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -894,25 +894,25 @@ CONTAINS
 !
            zolzz=zol(I)*(za(I)+z0q)/za(I)    ! (z+z0q)/L
            zol10=zol(I)*(10.+z0q)/za(I)   ! (10+z0q)/L
-           zol4=zol(I)*(4.+z0q)/za(I)     ! (4+z0q)/L ! PSH
+           zol4=zol(I)*(4.+z0q)/za(I)     ! (4+z0q)/L 
            zol2=zol(I)*(2.+z0q)/za(I)     ! (2+z0q)/L
            zol0=zol(I)*z0q/za(I)          ! z0q/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
-              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) 
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
-                psih4(I)=0. ! PSH
+                psih4(I)=0. 
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
-                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) 
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -952,25 +952,25 @@ CONTAINS
 !
            zolzz=zol(I)*(za(I)+z0t)/za(I)    ! (z+z0t)/L
            zol10=zol(I)*(10.+z0t)/za(I)   ! (10+z0t)/L
-           zol4=zol(I)*(4.+z0t)/za(I)     ! (4+z0t)/L ! PSH
+           zol4=zol(I)*(4.+z0t)/za(I)     ! (4+z0t)/L 
            zol2=zol(I)*(2.+z0t)/za(I)     ! (2+z0t)/L
            zol0=zol(I)*z0t/za(I)          ! z0t/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
-              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) 
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
-                psih4(I)=0. ! PSH
+                psih4(I)=0. 
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
-                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) 
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -999,8 +999,8 @@ CONTAINS
 
         U10(I)=UX(I)*PSIX10/PSIX                                    
         V10(I)=VX(I)*PSIX10/PSIX                                   
-        U4(I)=UX(I)*PSIX4/PSIX  ! PSH                                   
-        V4(I)=VX(I)*PSIX4/PSIX  ! PSH                                  
+        U4(I)=UX(I)*PSIX4/PSIX                                     
+        V4(I)=VX(I)*PSIX4/PSIX                                    
         TH2(I)=THGB(I)+DTG*PSIT2/PSIT                                
         Q2(I)=QSFC(I)+(QX(I)-QSFC(I))*PSIQ2/PSIQ                   
         T2(I) = TH2(I)*(PSFCPA(I)/P1000mb)**ROVCP                     

--- a/phys/module_sf_sfclayrev.F
+++ b/phys/module_sf_sfclayrev.F
@@ -16,7 +16,7 @@ CONTAINS
                      ZNT,UST,PBLH,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH, &
                      FM,FH,                                        &
                      XLAND,HFX,QFX,LH,TSK,FLHC,FLQC,QGH,QSFC,RMOL, &
-                     U10,V10,TH2,T2,Q2,                            &
+                     U10,V10,U4,V4,TH2,T2,Q2,                      & ! PSH
                      GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
@@ -144,6 +144,8 @@ CONTAINS
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(OUT  )               ::                U10, &
                                                               V10, &
+                                                               U4, & ! PSH
+                                                               V4, & ! PSH
                                                               TH2, &
                                                                T2, &
                                                                Q2, &
@@ -234,7 +236,8 @@ CONTAINS
                 MOL(ims,j),REGIME(ims,j),PSIM(ims,j),PSIH(ims,j),  &
                 FM(ims,j),FH(ims,j),                               &
                 XLAND(ims,j),HFX(ims,j),QFX(ims,j),TSK(ims,j),     &
-                U10(ims,j),V10(ims,j),TH2(ims,j),T2(ims,j),        &
+                U10(ims,j),V10(ims,j),U4(ims,j),V4(ims,j),         & ! PSH
+                TH2(ims,j),T2(ims,j),                              &
                 Q2(ims,j),FLHC(ims,j),FLQC(ims,j),QGH(ims,j),      &
                 QSFC(ims,j),LH(ims,j),                             &
                 GZ1OZ0(ims,j),WSPD(ims,j),BR(ims,j),ISFFLX,DX,     &
@@ -260,7 +263,7 @@ CONTAINS
                      CP,G,ROVCP,R,XLV,PSFCPA,CHS,CHS2,CQS2,CPM,PBLH,RMOL, &
                      ZNT,UST,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH,FM,FH,&
                      XLAND,HFX,QFX,TSK,                            &
-                     U10,V10,TH2,T2,Q2,FLHC,FLQC,QGH,              &
+                     U10,V10,U4,V4,TH2,T2,Q2,FLHC,FLQC,QGH,        & ! PSH
                      QSFC,LH,GZ1OZ0,WSPD,BR,ISFFLX,DX,             &
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
@@ -325,7 +328,7 @@ CONTAINS
                                                               QGH
 
       REAL,     DIMENSION( ims:ime )                             , &
-                INTENT(OUT)     ::                        U10,V10, &
+                INTENT(OUT)     ::                  U10,V10,U4,V4, & ! PSH
                                                 TH2,T2,Q2,QSFC,LH
 
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
@@ -358,6 +361,8 @@ CONTAINS
                                                            THX,QX, &
                                                             PSIH2, &
                                                             PSIM2, &
+                                                            PSIH4, & ! PSH
+                                                            PSIM4, & ! PSH
                                                            PSIH10, &
                                                            PSIM10, &
                                                            DENOMQ, &
@@ -365,6 +370,7 @@ CONTAINS
                                                           DENOMT2, &
                                                             WSPDI, &
                                                            GZ2OZ0, &
+                                                           GZ4OZ0, & ! PSH
                                                            GZ10OZ0
 !
       REAL,     DIMENSION( its:ite )        ::                     &
@@ -379,8 +385,8 @@ CONTAINS
       INTEGER ::  N,I,K,KK,L,NZOL,NK,NZOL2,NZOL10
 
       REAL    ::  PL,THCON,TVCON,E1
-      REAL    ::  ZL,TSKV,DTHVDZ,DTHVM,VCONV,RZOL,RZOL2,RZOL10,ZOL2,ZOL10
-      REAL    ::  DTG,PSIX,DTTHX,PSIX10,PSIT,PSIT2,PSIQ,PSIQ2,PSIQ10
+      REAL    ::  ZL,TSKV,DTHVDZ,DTHVM,VCONV,RZOL,RZOL2,RZOL10,ZOL2,ZOL4,ZOL10 ! PSH
+      REAL    ::  DTG,PSIX,DTTHX,PSIX10,PSIX4,PSIT,PSIT2,PSIQ,PSIQ2,PSIQ10 ! PSH
       REAL    ::  FLUXC,VSGD,Z0Q,VISC,RESTAR,CZIL,GZ0OZQ,GZ0OZT
       REAL    ::  ZW, ZN1, ZN2
 !
@@ -504,6 +510,7 @@ CONTAINS
       DO 260 I=its,ite
         GZ1OZ0(I)=ALOG((ZA(I)+ZNT(I))/ZNT(I))   ! log((z+z0)/z0)                                     
         GZ2OZ0(I)=ALOG((2.+ZNT(I))/ZNT(I))      ! log((2+z0)/z0)                           
+        GZ4OZ0(I)=ALOG((4.+ZNT(I))/ZNT(I))      ! log((2+z0)/z0)                           
         GZ10OZ0(I)=ALOG((10.+ZNT(I))/ZNT(I))    ! log((10+z0)z0)                    
         IF((XLAND(I)-1.5).GE.0)THEN                                            
           ZL=ZNT(I)                                                            
@@ -593,6 +600,7 @@ CONTAINS
 !
         zolzz=zol(I)*(za(I)+znt(I))/za(I) ! (z+z0/L
         zol10=zol(I)*(10.+znt(I))/za(I)   ! (10+z0)/L
+        zol4=zol(I)*(4.+znt(I))/za(I)     ! (4+z0)/L ! PSH
         zol2=zol(I)*(2.+znt(I))/za(I)     ! (2+z0)/L
         zol0=zol(I)*znt(I)/za(I)          ! z0/L
         ZL2=(2.)/ZA(I)*ZOL(I)             ! 2/L      
@@ -622,6 +630,8 @@ CONTAINS
         psim2(I)=psim_stable(zol2)-psim_stable(zol0)
         psih2(I)=psih_stable(zol2)-psih_stable(zol0)
 !
+        psim4(I)=psim_stable(zol4)-psim_stable(zol0) ! PSH 
+        psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH 
 ! ... paj: preparations to compute PSIQ. Follows CB05+Carlson Boland JAM 1978.
 !
         pq(I)=psih_stable(zol(I))-psih_stable(zl)
@@ -643,6 +653,8 @@ CONTAINS
         PSIH10(I)=PSIM10(I)                                           
         PSIM2(I)=0.                                                  
         PSIH2(I)=PSIM2(I)                                           
+        PSIM4(I)=0.        ! PSH                                          
+        PSIH4(I)=PSIM4(I)  ! PSH                                         
 !
 ! paj: preparations to compute PSIQ.
 !
@@ -671,6 +683,8 @@ CONTAINS
         psim2(I)=psim_unstable(zol2)-psim_unstable(zol0)
         psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
 !
+        psim4(I)=psim_unstable(zol4)-psim_unstable(zol0) ! PSH 
+        psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH 
 ! ... paj: preparations to compute PSIQ 
 !
         pq(I)=psih_unstable(zol(I))-psih_unstable(zl)
@@ -682,10 +696,12 @@ CONTAINS
         PSIH(I)=AMIN1(PSIH(I),0.9*GZ1OZ0(I))
         PSIM(I)=AMIN1(PSIM(I),0.9*GZ1OZ0(I))
         PSIH2(I)=AMIN1(PSIH2(I),0.9*GZ2OZ0(I))
+        PSIH4(I)=AMIN1(PSIH4(I),0.9*GZ4OZ0(I)) ! PSH
         PSIM10(I)=AMIN1(PSIM10(I),0.9*GZ10OZ0(I))
 !
 ! AHW: mods to compute ck, cd
         PSIH10(I)=AMIN1(PSIH10(I),0.9*GZ10OZ0(I))
+        PSIH4(I)=AMIN1(PSIH4(I),0.9*GZ4OZ0(I)) ! PSH
 
         RMOL(I) = ZOL(I)/ZA(I)  
 
@@ -697,6 +713,7 @@ CONTAINS
       DO 330 I=its,ite
         DTG=THX(I)-THGB(I)                                                   
         PSIX=GZ1OZ0(I)-PSIM(I)                                                   
+        PSIX4=GZ4OZ0(I)-PSIM4(I) ! PSH
         PSIX10=GZ10OZ0(I)-PSIM10(I)
 
 !     LOWER LIMIT ADDED TO PREVENT LARGE FLHC IN SOIL MODEL
@@ -731,20 +748,24 @@ CONTAINS
            zolzz=zol(I)*(za(I)+z0t)/za(I)    ! (z+z0t)/L
            zol10=zol(I)*(10.+z0t)/za(I)   ! (10+z0t)/L
            zol2=zol(I)*(2.+z0t)/za(I)     ! (2+z0t)/L
+           zol4=zol(I)*(4.+z0t)/za(I)     ! (4+z0t)/L ! PSH
            zol0=zol(I)*z0t/za(I)          ! z0t/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
+                psih4(I)=0. ! PSH
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -753,21 +774,25 @@ CONTAINS
 
            zolzz=zol(I)*(za(I)+z0q)/za(I)    ! (z+z0q)/L
            zol10=zol(I)*(10.+z0q)/za(I)   ! (10+z0q)/L
+           zol4=zol(I)*(4.+z0q)/za(I)     ! (4+z0q)/L ! PSH
            zol2=zol(I)*(2.+z0q)/za(I)     ! (2+z0q)/L
            zol0=zol(I)*z0q/za(I)          ! z0q/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
+                psih4(I)=0. ! PSH
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -790,21 +815,25 @@ CONTAINS
 !
            zolzz=zol(I)*(za(I)+z0q)/za(I)    ! (z+z0q)/L
            zol10=zol(I)*(10.+z0q)/za(I)   ! (10+z0q)/L
+           zol4=zol(I)*(4.+z0q)/za(I)     ! (4+z0q)/L ! PSH
            zol2=zol(I)*(2.+z0q)/za(I)     ! (2+z0q)/L
            zol0=zol(I)*z0q/za(I)          ! z0q/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
+                psih4(I)=0. ! PSH
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -832,21 +861,25 @@ CONTAINS
 !
            zolzz=zol(I)*(za(I)+z0t)/za(I)    ! (z+z0t)/L
            zol10=zol(I)*(10.+z0t)/za(I)   ! (10+z0t)/L
+           zol4=zol(I)*(4.+z0t)/za(I)     ! (4+z0t)/L ! PSH
            zol2=zol(I)*(2.+z0t)/za(I)     ! (2+z0t)/L
            zol0=zol(I)*z0t/za(I)          ! z0t/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
+                psih4(I)=0. ! PSH
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -861,21 +894,25 @@ CONTAINS
 !
            zolzz=zol(I)*(za(I)+z0q)/za(I)    ! (z+z0q)/L
            zol10=zol(I)*(10.+z0q)/za(I)   ! (10+z0q)/L
+           zol4=zol(I)*(4.+z0q)/za(I)     ! (4+z0q)/L ! PSH
            zol2=zol(I)*(2.+z0q)/za(I)     ! (2+z0q)/L
            zol0=zol(I)*z0q/za(I)          ! z0q/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
+                psih4(I)=0. ! PSH
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -915,21 +952,25 @@ CONTAINS
 !
            zolzz=zol(I)*(za(I)+z0t)/za(I)    ! (z+z0t)/L
            zol10=zol(I)*(10.+z0t)/za(I)   ! (10+z0t)/L
+           zol4=zol(I)*(4.+z0t)/za(I)     ! (4+z0t)/L ! PSH
            zol2=zol(I)*(2.+z0t)/za(I)     ! (2+z0t)/L
            zol0=zol(I)*z0t/za(I)          ! z0t/L
 !
               if (zol(I).gt.0.) then
               psih(I)=psih_stable(zolzz)-psih_stable(zol0)
               psih10(I)=psih_stable(zol10)-psih_stable(zol0)
+              psih4(I)=psih_stable(zol4)-psih_stable(zol0) ! PSH
               psih2(I)=psih_stable(zol2)-psih_stable(zol0)
               else
                 if (zol(I).eq.0) then
                 psih(I)=0.
                 psih10(I)=0.
+                psih4(I)=0. ! PSH
                 psih2(I)=0.
                 else
                 psih(I)=psih_unstable(zolzz)-psih_unstable(zol0)
                 psih10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+                psih4(I)=psih_unstable(zol4)-psih_unstable(zol0) ! PSH
                 psih2(I)=psih_unstable(zol2)-psih_unstable(zol0)
                 endif
               endif
@@ -958,6 +999,8 @@ CONTAINS
 
         U10(I)=UX(I)*PSIX10/PSIX                                    
         V10(I)=VX(I)*PSIX10/PSIX                                   
+        U4(I)=UX(I)*PSIX4/PSIX  ! PSH                                   
+        V4(I)=VX(I)*PSIX4/PSIX  ! PSH                                  
         TH2(I)=THGB(I)+DTG*PSIT2/PSIT                                
         Q2(I)=QSFC(I)+(QX(I)-QSFC(I))*PSIQ2/PSIQ                   
         T2(I) = TH2(I)*(PSFCPA(I)/P1000mb)**ROVCP                     

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -39,7 +39,7 @@ CONTAINS
      &          ,th10,th2,thz0,th_phy,tmn,tshltr,tsk,tslb             &
      &          ,tyr,tyra,tdly,tlag,lagday,nyear,nday,tmn_update,yr   &
      &          ,t_phy,u10,udrunoff,ust,uz0                           &
-     &          ,u_frame,u_phy,v10,vegfra,u10e,v10e,u4,v4,uoce,voce   & ! PSH
+     &          ,u_frame,u_phy,v10,vegfra,u10e,v10e,u4,v4,uoce,voce   & 
      &          ,vz0,v_frame,v_phy,warm_rain,wspd,xice,xland,z,znt    &
      &          ,max_edom,cplmask                                     &
 #if (HWRF==1)
@@ -2209,7 +2209,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                  p_phy,dz8w,cp,g,rcp,r_d,xlv,psfc,chs,chs2,cqs2,cpm, &
                  znt,ust,pblh,mavail,zol,mol,regime,psim,psih,fm,fhh, &
                  xland,hfx,qfx,lh,tsk,flhc,flqc,qgh,qsfc,rmol,       &
-                 u10,v10,u4,v4,th2,t2,q2,                            & ! PSH
+                 u10,v10,u4,v4,th2,t2,q2,                            & 
                  gz1oz0,wspd,br,isfflx,dx,                           &
                  svp1,svp2,svp3,svpt0,ep_1,ep_2,karman,eomeg,stbolt, &
                  P1000mb,                                            &
@@ -5939,7 +5939,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                      ZNT,UST,PBLH,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH, &
                      FM,FH,                                        &
                      XLAND,HFX,QFX,LH,TSK,FLHC,FLQC,QGH,QSFC,RMOL, &
-                     U10,V10,U4,V4,TH2,T2,Q2,                      & ! PSH
+                     U10,V10,U4,V4,TH2,T2,Q2,                      & 
                      GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
@@ -5986,8 +5986,8 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                INTENT(OUT  )               ::                U10, &
                                                              V10, &
-                                                              U4, & ! PSH
-                                                              V4, & ! PSH
+                                                              U4, & 
+                                                              V4, & 
                                                              TH2, &
                                                               T2, &
                                                               Q2, &
@@ -6101,8 +6101,8 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                                                 TSK_HOLD,         & !ssib
                                                 U10_HOLD,         & !ssib
                                                 V10_HOLD,         & !ssib
-                                                U4_HOLD,          & ! PSH
-                                                V4_HOLD,          & ! PSH
+                                                U4_HOLD,          & 
+                                                V4_HOLD,          & 
                                                 CD_SEA,           &
                                                 CDA_SEA,          &
                                                 CK_SEA,           &
@@ -6113,8 +6113,8 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                                                 U10_SEA,          &
                                                 USTM_SEA,         &
                                                 V10_SEA,          &
-                                                U4_SEA,           & ! PSH
-                                                V4_SEA              ! PSH
+                                                U4_SEA,           & 
+                                                V4_SEA              
 
      REAL,     DIMENSION( ims:ime, jms:jme ) ::                   &
                                                 BR_SEA,           &
@@ -6210,7 +6210,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                  ZNT,UST,PBLH,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH, &
                  FM,FH,                                        &
                  XLAND,HFX,QFX,LH,TSK_LOCAL,FLHC,FLQC,QGH,QSFC,RMOL, &
-                 U10,V10,U4,V4,TH2,T2,Q2,                      & ! PSH
+                 U10,V10,U4,V4,TH2,T2,Q2,                      & 
                  GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
                  SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                  KARMAN,EOMEG,STBOLT,                          &
@@ -6303,7 +6303,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                  HFX_SEA,QFX_SEA,LH_SEA,                       & ! I/O
                  TSK_SEA,                                      & ! I
                  FLHC_SEA,FLQC_SEA,QGH_SEA,QSFC_sea,RMOL_SEA,  & ! I/O
-                 U10_sea,V10_sea,U4_sea,V4_sea,                & ! PSH
+                 U10_sea,V10_sea,U4_sea,V4_sea,                & 
                  TH2_sea,T2_sea,Q2_sea,                        & ! O
                  GZ1OZ0_SEA,WSPD_SEA,BR_SEA,                   & ! I/O
                  ISFFLX,DX,                                    &

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -39,7 +39,7 @@ CONTAINS
      &          ,th10,th2,thz0,th_phy,tmn,tshltr,tsk,tslb             &
      &          ,tyr,tyra,tdly,tlag,lagday,nyear,nday,tmn_update,yr   &
      &          ,t_phy,u10,udrunoff,ust,uz0                           &
-     &          ,u_frame,u_phy,v10,vegfra,u10e,v10e,uoce,voce         &
+     &          ,u_frame,u_phy,v10,vegfra,u10e,v10e,u4,v4,uoce,voce   & ! PSH
      &          ,vz0,v_frame,v_phy,warm_rain,wspd,xice,xland,z,znt    &
      &          ,max_edom,cplmask                                     &
 #if (HWRF==1)
@@ -866,6 +866,8 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   V10
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   U10E
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   V10E
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   U4
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   V4
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   UOCE
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   VOCE
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT)::   PSFC
@@ -2207,7 +2209,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                  p_phy,dz8w,cp,g,rcp,r_d,xlv,psfc,chs,chs2,cqs2,cpm, &
                  znt,ust,pblh,mavail,zol,mol,regime,psim,psih,fm,fhh, &
                  xland,hfx,qfx,lh,tsk,flhc,flqc,qgh,qsfc,rmol,       &
-                 u10,v10,th2,t2,q2,                                  &
+                 u10,v10,u4,v4,th2,t2,q2,                            & ! PSH
                  gz1oz0,wspd,br,isfflx,dx,                           &
                  svp1,svp2,svp3,svpt0,ep_1,ep_2,karman,eomeg,stbolt, &
                  P1000mb,                                            &
@@ -2226,7 +2228,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                p_phy,dz8w,cp,g,rcp,r_d,xlv,psfc,chs,chs2,cqs2,cpm, &
                znt,ust,pblh,mavail,zol,mol,regime,psim,psih,fm,fhh, &
                xland,hfx,qfx,lh,tsk,flhc,flqc,qgh,qsfc,rmol,       &
-               u10,v10,th2,t2,q2,                                  &
+               u10,v10,u4,v4,th2,t2,q2,                            & !PSH
                gz1oz0,wspd,br,isfflx,dx,                           &
                svp1,svp2,svp3,svpt0,ep_1,ep_2,karman,eomeg,stbolt, &
                P1000mb,                                            &
@@ -5937,7 +5939,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                      ZNT,UST,PBLH,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH, &
                      FM,FH,                                        &
                      XLAND,HFX,QFX,LH,TSK,FLHC,FLQC,QGH,QSFC,RMOL, &
-                     U10,V10,TH2,T2,Q2,                            &
+                     U10,V10,U4,V4,TH2,T2,Q2,                      & ! PSH
                      GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,EOMEG,STBOLT,                          &
@@ -5984,6 +5986,8 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                INTENT(OUT  )               ::                U10, &
                                                              V10, &
+                                                              U4, & ! PSH
+                                                              V4, & ! PSH
                                                              TH2, &
                                                               T2, &
                                                               Q2, &
@@ -6097,6 +6101,8 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                                                 TSK_HOLD,         & !ssib
                                                 U10_HOLD,         & !ssib
                                                 V10_HOLD,         & !ssib
+                                                U4_HOLD,          & ! PSH
+                                                V4_HOLD,          & ! PSH
                                                 CD_SEA,           &
                                                 CDA_SEA,          &
                                                 CK_SEA,           &
@@ -6106,7 +6112,9 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                                                 TH2_SEA,          &
                                                 U10_SEA,          &
                                                 USTM_SEA,         &
-                                                V10_SEA
+                                                V10_SEA,          &
+                                                U4_SEA,           & ! PSH
+                                                V4_SEA              ! PSH
 
      REAL,     DIMENSION( ims:ime, jms:jme ) ::                   &
                                                 BR_SEA,           &
@@ -6178,6 +6186,8 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
      TSK_HOLD(its:ite,jts:jte)    = TSK(its:ite,jts:jte)
      U10_HOLD(its:ite,jts:jte)    = U10(its:ite,jts:jte) !fds (01/2014)
      V10_HOLD(its:ite,jts:jte)    = V10(its:ite,jts:jte) !fds (01/2014)
+     U4_HOLD(its:ite,jts:jte)     = U4(its:ite,jts:jte) !fds (01/2014)
+     V4_HOLD(its:ite,jts:jte)     = V4(its:ite,jts:jte) !fds (01/2014)
      
 ! INTENT(OUT) from SFCLAY.  Input shouldn't matter, but we'll want to
 ! keep things around for weighting after the second call to SFCLAY.
@@ -6200,7 +6210,7 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                  ZNT,UST,PBLH,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH, &
                  FM,FH,                                        &
                  XLAND,HFX,QFX,LH,TSK_LOCAL,FLHC,FLQC,QGH,QSFC,RMOL, &
-                 U10,V10,TH2,T2,Q2,                            &
+                 U10,V10,U4,V4,TH2,T2,Q2,                      & ! PSH
                  GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
                  SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                  KARMAN,EOMEG,STBOLT,                          &
@@ -6293,7 +6303,8 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
                  HFX_SEA,QFX_SEA,LH_SEA,                       & ! I/O
                  TSK_SEA,                                      & ! I
                  FLHC_SEA,FLQC_SEA,QGH_SEA,QSFC_sea,RMOL_SEA,  & ! I/O
-                 U10_sea,V10_sea,TH2_sea,T2_sea,Q2_sea,        & ! O
+                 U10_sea,V10_sea,U4_sea,V4_sea,                & ! PSH
+                 TH2_sea,T2_sea,Q2_sea,                        & ! O
                  GZ1OZ0_SEA,WSPD_SEA,BR_SEA,                   & ! I/O
                  ISFFLX,DX,                                    &
                  SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
@@ -6350,10 +6361,12 @@ e    &           ,htmx,croplive,gdd1020,gdd820,gdd020,grainc,grainc_storage  &
               t2(i,j)     = ( t2(i,j)     * XICE(i,j) ) + ( (1.0-XICE(i,j)) * t2_sea(i,j)     )
               th2(i,j)    = ( th2(i,j)    * XICE(i,j) ) + ( (1.0-XICE(i,j)) * th2_sea(i,j)    )
               u10(i,j)    = ( u10(i,j)    * XICE(i,j) ) + ( (1.0-XICE(i,j)) * u10_sea(i,j)    )
+              u4(i,j)    = ( u4(i,j)    * XICE(i,j) ) + ( (1.0-XICE(i,j)) * u4_sea(i,j)    )
               IF ( PRESENT ( USTM ) ) THEN
                  USTM(i,j)    = ( USTM(i,j)    * XICE(i,j) ) + ( (1.0-XICE(i,j)) * USTM_sea(i,j)    )
               ENDIF
               v10(i,j)    = ( v10(i,j)    * XICE(i,j) ) + ( (1.0-XICE(i,j)) * v10_sea(i,j)    )
+              v4(i,j)    = ( v4(i,j)    * XICE(i,j) ) + ( (1.0-XICE(i,j)) * v4_sea(i,j)    )
            ENDIF
         END DO
      END DO

--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -368,7 +368,7 @@ SUBROUTINE calc_ts( grid )
 
    ! Local variables
    INTEGER :: i, k, mm, n, ix, iy, rc
-   REAL :: earth_u, earth_v,                       &
+   REAL :: earth_u, earth_v, earth_u4, earth_v4,     &
            output_t, output_q, clw, xtime_minutes
    REAL, PARAMETER :: MISSING = -999.0
    REAL, ALLOCATABLE, DIMENSION(:) :: p8w
@@ -412,6 +412,8 @@ SUBROUTINE calc_ts( grid )
 #if (EM_CORE == 1)
             earth_u = grid%u_2(ix,1,iy)*grid%cosa(ix,iy)-grid%v_2(ix,1,iy)*grid%sina(ix,iy)
             earth_v = grid%v_2(ix,1,iy)*grid%cosa(ix,iy)+grid%u_2(ix,1,iy)*grid%sina(ix,iy)
+            earth_u4 = grid%u4(ix,iy)*grid%cosa(ix,iy)-grid%v4(ix,iy)*grid%sina(ix,iy)
+            earth_v4 = grid%v4(ix,iy)*grid%cosa(ix,iy)+grid%u4(ix,iy)*grid%sina(ix,iy)
             IF (grid%use_theta_m == 1) THEN
                output_t = (grid%t_2(ix,1,iy)+T0)/(1.+R_v/R_d*grid%moist(ix,1,iy,P_QV)) - T0
             ELSE
@@ -420,6 +422,8 @@ SUBROUTINE calc_ts( grid )
 #else
             earth_u = grid%u(ix,1,iy)
             earth_v = grid%v(ix,1,iy)
+            earth_u4 = grid%u(ix,1,iy)
+            earth_v4 = grid%v(ix,1,iy)
             output_t = grid%t(ix,1,iy)
 #endif
             output_q = grid%moist(ix,1,iy,P_QV)
@@ -446,10 +450,14 @@ SUBROUTINE calc_ts( grid )
             END DO
             earth_u = grid%u10(ix,iy)*grid%cosa(ix,iy)-grid%v10(ix,iy)*grid%sina(ix,iy)
             earth_v = grid%v10(ix,iy)*grid%cosa(ix,iy)+grid%u10(ix,iy)*grid%sina(ix,iy)
+            earth_u4 = grid%u4(ix,iy)*grid%cosa(ix,iy)-grid%v4(ix,iy)*grid%sina(ix,iy)
+            earth_v4 = grid%v4(ix,iy)*grid%cosa(ix,iy)+grid%u4(ix,iy)*grid%sina(ix,iy)
             output_q = grid%q2(ix,iy)
 #else
             earth_u = grid%u10(ix,iy)
             earth_v = grid%v10(ix,iy)
+            earth_u4 = grid%u4(ix,iy)
+            earth_v4 = grid%v4(ix,iy)
             output_q = grid%qsfc(ix,iy)
 #endif
             output_t = grid%t2(ix,iy)
@@ -549,6 +557,8 @@ SUBROUTINE calc_ts( grid )
          grid%ts_rainc(n,i)  = grid%rainc(ix,iy)
          grid%ts_rainnc(n,i) = grid%rainnc(ix,iy)
          grid%ts_tsk(n,i)  = grid%tsk(ix,iy)
+         grid%ts_u4(n,i)    = earth_u4
+         grid%ts_v4(n,i)    = earth_v4
          IF ( model_config_rec%process_time_series == 2 ) THEN
             !!! Solar diagnostics
             grid%ts_cldfrac2d(n,i) = grid%cldfrac2d(ix,iy)
@@ -646,6 +656,8 @@ SUBROUTINE calc_ts( grid )
          grid%ts_hour(n,i) = 1.E30
          grid%ts_u(n,i)    = 1.E30
          grid%ts_v(n,i)    = 1.E30
+         grid%ts_u4(n,i)   = 1.E30
+         grid%ts_v4(n,i)   = 1.E30
          grid%ts_t(n,i)    = 1.E30
          grid%ts_q(n,i)    = 1.E30
          grid%ts_psfc(n,i) = 1.E30
@@ -1022,6 +1034,12 @@ SUBROUTINE write_ts( grid )
    ts_buf(:,:) = grid%ts_ust(:,:)
    CALL wrf_dm_min_reals(ts_buf(:,:),grid%ts_ust(:,:),grid%ts_buf_size*grid%max_ts_locs)
 
+   ts_buf(:,:) = grid%ts_u4(:,:)
+   CALL wrf_dm_min_reals(ts_buf(:,:),grid%ts_u4(:,:),grid%ts_buf_size*grid%max_ts_locs)
+
+   ts_buf(:,:) = grid%ts_v4(:,:)
+   CALL wrf_dm_min_reals(ts_buf(:,:),grid%ts_v4(:,:),grid%ts_buf_size*grid%max_ts_locs)
+
    DEALLOCATE(ts_buf)
 #endif
 
@@ -1043,7 +1061,7 @@ SUBROUTINE write_ts( grid )
 
 #if (EM_CORE == 1)
             IF ( model_config_rec%process_time_series == 1 ) THEN
-               WRITE(UNIT=iunit,FMT='(i2,f13.6,i5,i5,i5,1x,16(f13.5,1x))')  &
+               WRITE(UNIT=iunit,FMT='(i2,f13.6,i5,i5,i5,1x,18(f13.5,1x))')  &
                                  grid%id, grid%ts_hour(n,i),                &
                                  grid%id_tsloc(i), ix, iy,                  &
                                  grid%ts_t(n,i),                            &
@@ -1061,7 +1079,9 @@ SUBROUTINE write_ts( grid )
                                  grid%ts_rainnc(n,i),                       &
                                  grid%ts_clw(n,i),                          &
                                  grid%ts_qfx(n,i),                          &
-                                 grid%ts_ust(n,i)
+                                 grid%ts_ust(n,i),                          &
+                                 grid%ts_u4(n,i),                           &
+                                 grid%ts_v4(n,i)
             ELSE
                !!! WRF-Solar diagnostics
                WRITE(UNIT=iunit,FMT='(i2,f13.6,i5,i5,i5,1x,49(f13.5,1x))')  &

--- a/share/wrf_timeseries.F
+++ b/share/wrf_timeseries.F
@@ -285,7 +285,7 @@ SUBROUTINE calc_ts_locations( grid )
 
                ts_profile_filename = grid%ts_filename(k)
 
-               ! PSH
+               
                IF ( grid%tslist_turbulent_output == 0 ) THEN
                   ! No turbulent tower data
                   n_ts_files = SIZE(ts_file_endings) - 13
@@ -487,7 +487,6 @@ SUBROUTINE calc_ts( grid )
             grid%ts_u_profile(n,i,k)   = earth_u_profile(k)
             grid%ts_v_profile(n,i,k)   = earth_v_profile(k)
 
-            !PSH
             IF (config_flags%tslist_unstagger_winds) THEN
                 grid%ts_w_profile(n,i,k)   = (grid%w_2(ix,k,iy)+grid%w_2(ix,k+1,iy))/2.0 ! w on half levels
                 grid%ts_gph_profile(n,i,k) = ((grid%phb(ix,k,iy)+grid%ph_2(ix,k,iy))/9.81 + &
@@ -806,7 +805,7 @@ SUBROUTINE write_ts( grid )
 
    IF ( grid%tslist_turbulent_output == 2 ) THEN
        IF ( (grid%km_opt /= 1) .AND. (grid%km_opt /= 4) ) THEN
-           ! - - - - - - SGS LES - - - - - PSH
+           ! - - - - - - SGS LES - - - - - 
            DO k=1,grid%max_ts_level
            ts_buf(:,:) = grid%ts_m11_profile(:,:,k)
            CALL wrf_dm_min_reals(ts_buf(:,:),grid%ts_m11_profile(:,:,k),grid%ts_buf_size*grid%max_ts_locs)


### PR DESCRIPTION
Average buoy anemometer height is ~4 m, so I have added output
similar to U10 and V10 but at 4 m instead. This is available as 2D
output and within the tslist output

TYPE: enhancement

DESCRIPTION OF CHANGES:
Taking U10 and V10 as an example, this code generates output for U and V at 4 m. This is useful for comparison with buoy anemometer data that has an average height of 4 m.

TESTS CONDUCTED: 
1. Compiled with GNU and Intel
2. Ran test case with U4 and V4 as output and with tslist activated. All output produced was as expected.
